### PR TITLE
Default etcdctl API version to v3 in infra composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ docker exec -it telemetry-infra_kafka_1 \
 
 **NOTE** the use of port 9093 instead of 9092
 
+### Querying etcd
+
+The etcd container includes the `etcdctl` command-line tool and is pre-configured to use the v3
+API. You can perform operations with `etcdctl` via `docker exec`, such as:
+
+```bash
+docker exec -it telemetry-infra_etcd_1 etcdctl get --prefix /
+```
+
 ### Applications
 
 _**NOTE** The following procedure is IntelliJ specific but the process will be similar for other IDEs._

--- a/dev/telemetry-infra/docker-compose.yml
+++ b/dev/telemetry-infra/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - 2479:2379
     volumes:
       - etcd:/etcd-data
+    environment:
+      ETCDCTL_API: 3
     command: >
       /usr/local/bin/etcd
       --data-dir=/etcd-data --name node1


### PR DESCRIPTION
# What

Defaults the etcdctl API version to v3 in the infra composition's etcd container, which makes it much easier to exec into the container to run etcdctl.

# How

Sets the environment variable via the image definition, which also gets applied for exec'ed sessions.

## How to test

```
docker exec -it telemetry-infra_etcd_1 etcdctl -h
```

and confirm it shows:
```
API VERSION:
	3.3
```

# Why

n/a

# TODO

none