### PR TITLE
Rename libs/label-management to libs/etcd-adapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "apps/envoy"]
 	path = apps/envoy
 	url = git@github.com:racker/salus-telemetry-envoy.git
-[submodule "libs/label-management"]
-	path = libs/label-management
-	url = git@github.com:racker/salus-telemetry-label-management.git
 [submodule "apps/auth-service"]
 	path = apps/auth-service
 	url = git@github.com:racker/salus-telemetry-auth-service.git
@@ -22,3 +19,6 @@
 [submodule "libs/common"]
 	path = libs/common
 	url = git@github.com:racker/salus-common.git
+[submodule "libs/etcd-adapter"]
+	path = libs/etcd-adapter
+	url = git@github.com:racker/salus-telemetry-etcd-adapater.git

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <modules>
         <module>libs/model</module>
-        <module>libs/label-management</module>
+        <module>libs/etcd-adapter</module>
         <module>libs/common</module>
 
         <module>apps/ambassador</module>


### PR DESCRIPTION
# What

Rename the `libs/label-management` submodule reference to `libs/etcd-adapter` to match the repo rename.

# How

Used these commands to add the new submodule location, deinit the old path, remove it from .gitmodules:

```
git submodule add git@github.com:racker/salus-telemetry-etcd-adapater.git libs/etcd-adapter
git submodule deinit libs/label-management
git rm libs/label-management
```

## How to test

n/a

# Why

n/a

# TODO

In a separate PR I'll rename the artifact ID:

https://github.com/racker/salus-telemetry-etcd-adapater/blob/master/pom.xml#L26