### PR TITLE
Adjust for fixed salus-telemetry-etcd-adapter repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = git@github.com:racker/salus-common.git
 [submodule "libs/etcd-adapter"]
 	path = libs/etcd-adapter
-	url = git@github.com:racker/salus-telemetry-etcd-adapater.git
+	url = git@github.com:racker/salus-telemetry-etcd-adapter.git


### PR DESCRIPTION
# Resolves

n/a

# What

The https://github.com/racker/salus-telemetry-etcd-adapter repo name has been misspelled and this PR adjusts the submodule url to match the corrected repo name/url.

# How

Only changed the `.gitmodule` file. I wasn't sure if some `git submodule` command was needed or will be needed to adjust things.

## How to test

n/a

# Why

n/a

# TODO

none