### PR TITLE
Add Docker compose files for mysql and mongodb for researching

### DIFF
--- a/dev/telemetry-infra/docker-compose-mongodb.yml
+++ b/dev/telemetry-infra/docker-compose-mongodb.yml
@@ -1,0 +1,12 @@
+version: '3.2'
+
+services:
+  mongodb:
+    image: mongo:3
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb:/data
+
+volumes:
+  mongodb:

--- a/dev/telemetry-infra/docker-compose-mysql.yml
+++ b/dev/telemetry-infra/docker-compose-mysql.yml
@@ -1,0 +1,16 @@
+version: '3.2'
+
+services:
+  mysql:
+    image: mysql:${MYSQL_VERSION:-5.7}
+    ports:
+      - 3306:3306
+    volumes:
+      - mysql:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: default
+      MYSQL_ROOT_PASSWORD: ${MYSQL_INITIAL_PASSWORD:-initialpw}
+      MYSQL_ONETIME_PASSWORD: "true"
+
+volumes:
+  mysql:


### PR DESCRIPTION
# Resolves

Part of researching SALUS-91

# What

Add "optional" Docker compose files for running MySQL and/or MongoDB for researching the datastore options.