### PR TITLE
Add libs/protocol submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "apps/check-config"]
 	path = apps/check-config
 	url = git@github.com:racker/salus-telemetry-check-config.git
+[submodule "libs/protocol"]
+	path = libs/protocol
+	url = git@github.com:racker/salus-telemetry-protocol.git

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <module>apps/ambassador</module>
         <module>apps/api</module>
         <module>apps/auth-service</module>
-        <!--<module>apps/check-config</module>-->
+        <module>apps/check-config</module>
         <module>apps/presence-monitor</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,12 @@
         <module>libs/model</module>
         <module>libs/etcd-adapter</module>
         <module>libs/common</module>
+        <module>libs/protocol</module>
 
         <module>apps/ambassador</module>
         <module>apps/api</module>
         <module>apps/auth-service</module>
-        <module>apps/check-config</module>
+        <!--<module>apps/check-config</module>-->
         <module>apps/presence-monitor</module>
     </modules>
 


### PR DESCRIPTION
# What

Add the libs/protocol submodule, which will contain just the Avro and protobuf/gRPC definitions.

Follow up of https://github.com/racker/salus-telemetry-protocol/pull/1