### PR TITLE
Remove check-config repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,6 @@
 [submodule "presence-monitor"]
 	path = apps/presence-monitor
 	url = git@github.com:racker/salus-telemetry-presence-monitor.git
-[submodule "apps/check-config"]
-	path = apps/check-config
-	url = git@github.com:racker/salus-telemetry-check-config.git
 [submodule "libs/protocol"]
 	path = libs/protocol
 	url = git@github.com:racker/salus-telemetry-protocol.git


### PR DESCRIPTION
This isn't needed yet and is causing problems.  We also need to rename this to monitor-management anyway.