### PR TITLE
Adding required resource_id to our dev Envoy configs

### DIFF
--- a/dev/envoy-config-authserv-keystone.yml
+++ b/dev/envoy-config-authserv-keystone.yml
@@ -1,3 +1,4 @@
+resource_id: "development:0"
 tls:
   auth_service:
     url: http://localhost:8182

--- a/dev/envoy-config-authserv.yml
+++ b/dev/envoy-config-authserv.yml
@@ -1,3 +1,4 @@
+resource_id: "development:0"
 tls:
   auth_service:
     url: http://localhost:8082

--- a/dev/envoy-config-provided-tenantB.yml
+++ b/dev/envoy-config-provided-tenantB.yml
@@ -1,3 +1,4 @@
+resource_id: "development:0"
 tls:
   provided:
     ca: certs/out/ca.pem

--- a/dev/envoy-config-provided.yml
+++ b/dev/envoy-config-provided.yml
@@ -1,3 +1,4 @@
+resource_id: "development:0"
 tls:
   provided:
     ca: certs/out/ca.pem


### PR DESCRIPTION
# Resolves

Part of SALUS-112

# What

Adding the `resource_id` field to the Envoy configurations since that is now required by the Envoy during startup.

## How to test

Run the Envoy in local dev environment as before.