### PR TITLE
Capture some docs and Grafana dashboards used for end to end demo

### DIFF
--- a/dev/envoy-config-provided.yml
+++ b/dev/envoy-config-provided.yml
@@ -1,4 +1,6 @@
 resource_id: "development:0"
+labels:
+  environment: localdev
 tls:
   provided:
     ca: certs/out/ca.pem

--- a/dev/kapacitor-event-ingest/README.md
+++ b/dev/kapacitor-event-ingest/README.md
@@ -51,3 +51,10 @@ The following is example JSON content produced by the Kapacitor Kakfa event hand
   "recoverable": true
 }
 ```
+
+## Grafana Dashboards
+
+The ingested events can be viewed in Grafana along with the raw metrics by using the following two dashboards, 
+where the second annotates the metrics chart with the events:
+- [Overview Dashboard JSON](grafana-dashboards/Overview.json)
+- [Detailed Dashboard JSON](grafana-dashboards/Detailed.json)

--- a/dev/kapacitor-event-ingest/grafana-dashboards/Detailed.json
+++ b/dev/kapacitor-event-ingest/grafana-dashboards/Detailed.json
@@ -28,9 +28,23 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1551820596469,
+  "iteration": 1551970906579,
   "links": [],
   "panels": [
+    {
+      "content": "<h1 style=\"text-align:center\"><img style=\"height:50px\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAyVBMVEX///8AAADFACLCAADFACDEABzEABrEABbEABPDABDDAAnAAADDABXV1dX5+fnDAAz98/Xp6el6enrIyMhVVVXc3Nynp6e1tbXy8vLi4uKdnZ0uLi5QUFD67O6Pj4+WlpYeHh6Dg4P34+baeYPxz9Por7VsbGxdXV3CwsK4uLjcg4zLLkHVZXDuwsfei5MMDAzmqa89PT1mZmbjnKMhISHRSlrSVWLuw8jXbnfjnqXHEy3qtrvKJzvNPU312d0XFxdCQkLMNkbTXGfzkBoDAAAQAklEQVR4nN1daUMaPRBeyYKCChTPakXB+yhqqYiC1/v/f9S7y7WTZJJNJoNony/9UAn7kGTumY2iBWN7/+h2aYyjv/fnjdbe5caP6qKfihHbSyj2N5uXPxf9bCwwEJxg83Dju+/mpZXgCO+HW4t+ygBc5BNM8dbaWPSTErHhRnCE1nfcyXUPggnutxf9wL746UcwReNbidddf4IJztcX/dzOqB6RGC4t/fouHO+JBNN9/BZn9ZxOMEFjd9HPn4tGEMEEX12u7oUSTHTHl9aPO8kT3u6/n7Wae9s7FxsjXOxs7zVb5/d/nTk2F03Dgp2NH+aLVP2xfnl4tu9Acf9bSBwztrYbufv51W9jPnYvc0TSn0U/IQe2Dm2q8/abn9QJfh6+mTl+V8dKxfqZkeLeop/Ninr7JMHg9PT0d/Lva9sSs9g9NFFsfd7zOqP+Ong6/u8lFipWa8Nev3v6eoB+bNtwWM8++fHtaA86vUJFiMrKcjGOCyriuLRWS6gWep3fCE1D4Or883mgqD92eiUhyiWEmU60LMSwf9pWF2miFH8tgo+M6knnWohaKZebxHNNiOerE3mlXdQt2VwMrSkO7nplUS56sZuxLIti/1FaDo3QLVD3t7vD1coyiV22lZWrV7Bk9Q9CsbEYegfda1ErBrDLdrIH191BKC5AL1YHD6LCQG+EWkda+yfifFx8Mr/X47IoMdFLNlEoUhUzVj/VRh28iJX8u+d+O0sv8vqoz3H7aWmcereQu33FtUTtOxMsiIH0DYZ8wCfpjIMrUbFuTpySu+4/PR6cuMrYuCx9RRUn+DnSpt0XZetjVxJT5W4s+9vC9ZiWr6QvMcci5x6fOujnXT/xNDM36wVnQSvLGUvW8Wi+/OpXueJFdLM/Hy67ElyWlKE14zFXV6pbq+WdutpN9ue9sivBgpDMtk0bw6X5pTUGsV2+pCgNs7+/cpekxWv4RZg9A/B3TvxeXxykRlzJrtPAR1Wcgm/6YSc4J3laPXYyX1Z/zz7hLkaTH6YIv8t+RlPMIW0zWK45bQUQ+UMPg048ge/KOaMp2IMaBz23/VgGhlff6ScZIy4BY8wpc8ysFO+Em9CPy/XZZ/RLGBeNDnIFKBi3vCNrTKP+4HqhRHYJ64rWLAlR+xgKgRoAsQBf51iAw6gxBo4bKF/C3prM7+F0ZOc8XmMaEt5Coz06t03sO0vE0gf8WaQtesgCFA9r2gfjIriFzqljpk18fXaWF7HIgp/SGV0p/gYrVnWPUdxl/+1eYsQTQL3D7w0KqLP74CyKXl1a86mi/jQF8L/u+WEWd//GQ2evAHP0JDujsegoi7ZVIQs9X2PiAkF45K09pGq065muj+EJnECVsuD65pprEkIDGideQSboGpzOdimWzM0JhvLJFyDgnW+uQQQmwLseJzRxmY7BR7OcBbKDyQ5LDNf+y/7HURVOsR9E8NiLoCQsnmZbKK6wpZ/hylACR5Y0MIoQWfPg4fikjwlOWnX226z00LWl364CBBGec7KA7uzXh+6++egx4V51ptogLtSxxSVZCjffT8ykOKISbBecoyvaY0bVmXktTtDVTyFDYMlSKv2Ids2rh5rXqdxNCZT7+PI34OdbA+fYs2B6BFpV2IkvQZnK1CiLV9AzGlVBqEcSMy5FYCreKAR/ewnRgmI3Jx+fbuwTvj60yaEycXDsERCkqTdBJd3w3+QMKjH6DB+ZHQEjAhGJIEHp+xOUI7kH089XDFsomazgjHprijG8HQx/gtJjJpbQRFXENfwWRg/ZFsIzSqvqTzB3glIIP8pszjWDIH3MtnAFmGv0kmm/iNSJP8His7TCTJtDPQfxPJPTRWgP+Cv7Kbwu4qs/QVWrT71bKbQEMLN3kr+AlRdY4YUbfAKnbYeUtYq1G3mN6S0rPRh+w+yngZJoi0zQRyPWn/1rDmIhy5OZ0b1yjH5FFqKpSPf0F52hR3zfPdOXQREzmSqoYH4hCLNJmpBkr83gbJp6ZPqyLXxWFulOwx5K0cEY/dkZLcbS3vt59gp2HAkee/mDUx6qwJwZ1RjDLJkIM3BR4Ba6+oh3FIJq/Qvw3pFTCgiuygI45Ba6WjUERajK+xT1WYXGmiZpbkB0St76sC1cOnIheEDQE7qmAEap7BOn3F8yRbiqnOCgW7jkZrddE8SoapCmAPEJ+SIOKsvZxxSCAbpwjB/5BPtqmN0JNT2OBv2GUsa/DdKrGsEAc2aCfHVxSpEyiTzUnQfAsFAsTULEjzcgO6cTJPRCK8htN/GpJwBY7epLncgptefjq6veMsw+FuWimRTBfZj5trdPPQF4/hhJGig5l3ilXJbK9pZXVOnrnA+14DCH4DHpEuLh+gP7cah96AfbJ9dkQE687XGVRFDVBhPYmixioWmXBLf5DPJgN2rqxAJ7LKUUyaFQBUV012kBNhn2HoX/VkgENZN7AmOZV1wZalcwBSVGqsJqtvkUnkEYtjCqGgprS3gSKtRgG8NWlEE9o3FsWrGD/WSxuEY3MIrMDYdMDG9oZ9S4hRGme+JKEXWHo4AQoivDR+IZNd3CFAdrsrApihJiGkxgHyDFwPCZdkaNGYkxxeEssRMXa+LatH8pOOSMjWGHpusTU8Xy0AlOh0JUamkL5XXHcP/GYJEzFoZEe1SpI8SXHjx1uqePhrj+DOEm6QhGfdijOIUFucIyDDwEjTFhqphRGz/o8CwtMcJktQ2JLXWIa09E2ICeDAbLmxRcS2FKKnmDwW8aw+A9kWJPKbQAGxUcRvcIuAfcJWoKU8qFgNAQ2wxoFEMtwvbYQkNe0Bs8FlsKNBLV8SirlFAcYstRwHZI0WhinarsjfUH/uCSpHhEmLyFseDqwmWTpGiXF/0W4olPCnyGftqB9QWTBSmfqohabAyxam+PBnIZejqNDN9aWTMQdUiL4o+2EMvskhAey58BUYfX1CEPphISAni8+xF0ZXFC3kI2r4Ih4ZRBX9wStc2BOrYiAAyh7gl0Dz8nt2ABo5xhvIa67xSgKswxRF8wXkN9nAs1wMZoz7BFaFJogoYuZ9hc34jzGh5pa/f1/kZHGHoLKODznPQwVNVv1BhA0RLo9gWfUapbNL/pylBtIwwAw4jhKbRafboyXOVThjwppzG0tcnKsPiBPCkVPPmKFJpjQT+k+aF8d/B5v0uX6tpkScoXB45YLRqtQPgreIZ84XzEKKWre7yqmQg+UarpCnIEqsB5SBltNu2Qkn1fvkh3CrZo97268lcIk6Zgi9EwGjSMvm/ElhlF/IorQsPBCPIcrlCw2d26e/9BvYY1RnXPqA61Tgv6NeQLBKcILuyeQluZrA1jtoTTCFy+kx7sJkdoGKOIKbjyanrekOw56cXZCqobzT/7R0d/78/2HPqsmMJQmjKE7Zt+yAt1X8ipwEYeSSaGekcXWdAsY9XL2fPq+vvd3h/AZJbqC79SBY0tTrqBv3fs3NbHwsMQqaKhppxsrqE5HGFpgmixMERaRztEi8Zs0Py0vTjO3IHMwhBbnipKjUG2HEd23xQiZ2GIzcOg2mwmXZGr1m4NPcjE+RAS0IpL+3xqI0y6wkVe4BQ5JA02SaFOFDQG59fJMHlDDyoDQ3QuO1VZ4H6Fo22J2B0sGh+dSkO1u9GEjLMDhN2XcIZ43TOxPSYuIWtV3eMQiF4Mt7xxe0KbOOmGEjZyzSeUpMuEYO/JMBGSGEnErqHXMdMncwR7wAYtRDRpkGvoOUtGKzQPjWKYppUfk1IWmDZ893wi9ZwGRqJuDQSJRhuiDb1FoTahMoyh8V06PVJDc00zSgk7oPqqHoN0dZhfwvJAYsjTXa4sEVTyZfY8SQx135AkCJWOiFYAQUtrOo2hVoBBy6rI9mmAUWN7sQWJoVYlRGyok3/5AJVvi3KRGGqJUeqwHGkRurqwzrcmNeOp+p7cEymbp9SiryMbQZI+1Ir1yE0Ssu1GPQn2SOwxoW+7qNQn0Gf/yXq6RVsjZwAGxS5V2yuIT5ZCUtQ0/ylvejfFt1AETVClD9TUNNs7b1rSHcE/VPKGQa6rpDAoC+ROniMk8dWpiLa3g+dC0tUEuyF/xiUhTqNYNIF+HRSE/uE2hxH62lsl8qEknQIjudAT9terDiPLCIWXSgQjyOlZkuwab5nl9IJV/yJ9uSM2eMYDPKaeF9Ft9Lq/2SbXCQWnG+Bj+rkXju9y9q4Xipclmy24VgsKCy+p5fqiDu8MqVz4zFDnA6WFj/HtOkfXO3Ehi1KGbAPU2S33jzmPzq/nvl5TgSxKw8aojgC9O3cvOHcsYgbf6lKpY5Sl+hw+jetnXMcEp/AVNZJVylKqBS+iY8+F1+s4fbNPq9Aq5UhNS70Dbj+Z3ztIDvwYxhX44SCrewopheHyAd/3jvldRCmgz9ME8g6fxiG07P1iNb+LKEUSmcZyQRMi/5j6vznOz4GSlAVTtZ2UhuIn6OleSMqCqdtMalPKEV6kd/95RRSlWClTA4Ekaux2IO2FY16RDJiU4eo2k0eN2lKtecOBDah6jG2RXkjFJGiU6L4lskV+s6FHd540L4mtf16OoRv/zMmlR+EhTaV+vBYXQ9lPMKnEkPfguocyJN+JwbEYQ3YU8HTrkUvUyYgn5+HWUllpaBBqBul+/UT7gd/DRje4O4mw8ZdvQgC0pHF9GPwKXOcUFFT4ATknBVlMaQtv6A58PWyCtusxhQqfbwbCrN2shf8/x7u2bxwVBvR/+ebjTcJmhhLxXyzTU1yH60KThmG8/xTpcj8M8WCiHaPBcRNXwUcYx8kkhlUL/59bprfBu26iNPCZcY5F1WQenfPN94mOXRxhqeeQJYRhh09ILRdOLV5SDGPu/H65vx7OCU8O1qlktM2bIOsGjuAwB1qK0syX3znzBqY4yVf7sNCEcdqKjlu6p2RD/utzYOksn9Gmg/baaQfkdszCUhrGeTIKNoMcJSte884pbBxla6BXsJ/peEZlOAX6uhTIELgW82F4m4UWL5p7DX5x82CPLMIqBbY4FARwkzZ2dprrwX6hhvqa9SpC52kODCU3sBE1qoc7/FfS/t7KeTJ8U9zcZnT+Hs1DqFpLF2ClCS/DfW0CWXN9fXudy3WScGWhCN1DTobnmI/UPGx65XrdcWNW/HNheNucg4Fmx4OprFZqJWHSFpvzsc9y8GLwFdkZ3m9/+vbZKUoMg622/UPnqp854AU9qFLmKczy/rU9P+PTDT3MRJUYRg1qC8hb42JRhxPiBlEaMsPkKu55N5PsN+ZgphDR0a0blWGK9e0z2zATgL9nextz8BYCMBCqjYoxTLG7vtM6t2Si3s8OL7e+wsFU8fq84sZwgt2tjZ29w2bj7M/m5uafs7Nmc297Y32RAjMX9Qf5pOYw/JZ4EqV/nGH0OgTb+E8yTGUqeIs959DZr4P27Db+qwwTvfE85vjvMoyi7nIl5fgPM4zqHZFw/JcZRlG1WxC8Q1m/IAYffO/r+Az8D93bYitVpONHAAAAAElFTkSuQmCC\">\nRackspace Monitoring</h1>",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "type": "text"
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -42,7 +56,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 2,
       "legend": {
@@ -176,10 +190,10 @@
       "datasource": "InfluxDB",
       "fontSize": "100%",
       "gridPos": {
-        "h": 8,
+        "h": 3,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 11
       },
       "id": 4,
       "links": [],
@@ -395,5 +409,5 @@
   "timezone": "",
   "title": "Detailed",
   "uid": "vZWyTBXmz",
-  "version": 10
+  "version": 12
 }

--- a/dev/kapacitor-event-ingest/grafana-dashboards/Detailed.json
+++ b/dev/kapacitor-event-ingest/grafana-dashboards/Detailed.json
@@ -28,11 +28,11 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1551970906579,
+  "iteration": 1552944546488,
   "links": [],
   "panels": [
     {
-      "content": "<h1 style=\"text-align:center\"><img style=\"height:50px\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAyVBMVEX///8AAADFACLCAADFACDEABzEABrEABbEABPDABDDAAnAAADDABXV1dX5+fnDAAz98/Xp6el6enrIyMhVVVXc3Nynp6e1tbXy8vLi4uKdnZ0uLi5QUFD67O6Pj4+WlpYeHh6Dg4P34+baeYPxz9Por7VsbGxdXV3CwsK4uLjcg4zLLkHVZXDuwsfei5MMDAzmqa89PT1mZmbjnKMhISHRSlrSVWLuw8jXbnfjnqXHEy3qtrvKJzvNPU312d0XFxdCQkLMNkbTXGfzkBoDAAAQAklEQVR4nN1daUMaPRBeyYKCChTPakXB+yhqqYiC1/v/f9S7y7WTZJJNJoNony/9UAn7kGTumY2iBWN7/+h2aYyjv/fnjdbe5caP6qKfihHbSyj2N5uXPxf9bCwwEJxg83Dju+/mpZXgCO+HW4t+ygBc5BNM8dbaWPSTErHhRnCE1nfcyXUPggnutxf9wL746UcwReNbidddf4IJztcX/dzOqB6RGC4t/fouHO+JBNN9/BZn9ZxOMEFjd9HPn4tGEMEEX12u7oUSTHTHl9aPO8kT3u6/n7Wae9s7FxsjXOxs7zVb5/d/nTk2F03Dgp2NH+aLVP2xfnl4tu9Acf9bSBwztrYbufv51W9jPnYvc0TSn0U/IQe2Dm2q8/abn9QJfh6+mTl+V8dKxfqZkeLeop/Ninr7JMHg9PT0d/Lva9sSs9g9NFFsfd7zOqP+Ong6/u8lFipWa8Nev3v6eoB+bNtwWM8++fHtaA86vUJFiMrKcjGOCyriuLRWS6gWep3fCE1D4Or883mgqD92eiUhyiWEmU60LMSwf9pWF2miFH8tgo+M6knnWohaKZebxHNNiOerE3mlXdQt2VwMrSkO7nplUS56sZuxLIti/1FaDo3QLVD3t7vD1coyiV22lZWrV7Bk9Q9CsbEYegfda1ErBrDLdrIH191BKC5AL1YHD6LCQG+EWkda+yfifFx8Mr/X47IoMdFLNlEoUhUzVj/VRh28iJX8u+d+O0sv8vqoz3H7aWmcereQu33FtUTtOxMsiIH0DYZ8wCfpjIMrUbFuTpySu+4/PR6cuMrYuCx9RRUn+DnSpt0XZetjVxJT5W4s+9vC9ZiWr6QvMcci5x6fOujnXT/xNDM36wVnQSvLGUvW8Wi+/OpXueJFdLM/Hy67ElyWlKE14zFXV6pbq+WdutpN9ue9sivBgpDMtk0bw6X5pTUGsV2+pCgNs7+/cpekxWv4RZg9A/B3TvxeXxykRlzJrtPAR1Wcgm/6YSc4J3laPXYyX1Z/zz7hLkaTH6YIv8t+RlPMIW0zWK45bQUQ+UMPg048ge/KOaMp2IMaBz23/VgGhlff6ScZIy4BY8wpc8ysFO+Em9CPy/XZZ/RLGBeNDnIFKBi3vCNrTKP+4HqhRHYJ64rWLAlR+xgKgRoAsQBf51iAw6gxBo4bKF/C3prM7+F0ZOc8XmMaEt5Coz06t03sO0vE0gf8WaQtesgCFA9r2gfjIriFzqljpk18fXaWF7HIgp/SGV0p/gYrVnWPUdxl/+1eYsQTQL3D7w0KqLP74CyKXl1a86mi/jQF8L/u+WEWd//GQ2evAHP0JDujsegoi7ZVIQs9X2PiAkF45K09pGq065muj+EJnECVsuD65pprEkIDGideQSboGpzOdimWzM0JhvLJFyDgnW+uQQQmwLseJzRxmY7BR7OcBbKDyQ5LDNf+y/7HURVOsR9E8NiLoCQsnmZbKK6wpZ/hylACR5Y0MIoQWfPg4fikjwlOWnX226z00LWl364CBBGec7KA7uzXh+6++egx4V51ptogLtSxxSVZCjffT8ykOKISbBecoyvaY0bVmXktTtDVTyFDYMlSKv2Ids2rh5rXqdxNCZT7+PI34OdbA+fYs2B6BFpV2IkvQZnK1CiLV9AzGlVBqEcSMy5FYCreKAR/ewnRgmI3Jx+fbuwTvj60yaEycXDsERCkqTdBJd3w3+QMKjH6DB+ZHQEjAhGJIEHp+xOUI7kH089XDFsomazgjHprijG8HQx/gtJjJpbQRFXENfwWRg/ZFsIzSqvqTzB3glIIP8pszjWDIH3MtnAFmGv0kmm/iNSJP8His7TCTJtDPQfxPJPTRWgP+Cv7Kbwu4qs/QVWrT71bKbQEMLN3kr+AlRdY4YUbfAKnbYeUtYq1G3mN6S0rPRh+w+yngZJoi0zQRyPWn/1rDmIhy5OZ0b1yjH5FFqKpSPf0F52hR3zfPdOXQREzmSqoYH4hCLNJmpBkr83gbJp6ZPqyLXxWFulOwx5K0cEY/dkZLcbS3vt59gp2HAkee/mDUx6qwJwZ1RjDLJkIM3BR4Ba6+oh3FIJq/Qvw3pFTCgiuygI45Ba6WjUERajK+xT1WYXGmiZpbkB0St76sC1cOnIheEDQE7qmAEap7BOn3F8yRbiqnOCgW7jkZrddE8SoapCmAPEJ+SIOKsvZxxSCAbpwjB/5BPtqmN0JNT2OBv2GUsa/DdKrGsEAc2aCfHVxSpEyiTzUnQfAsFAsTULEjzcgO6cTJPRCK8htN/GpJwBY7epLncgptefjq6veMsw+FuWimRTBfZj5trdPPQF4/hhJGig5l3ilXJbK9pZXVOnrnA+14DCH4DHpEuLh+gP7cah96AfbJ9dkQE687XGVRFDVBhPYmixioWmXBLf5DPJgN2rqxAJ7LKUUyaFQBUV012kBNhn2HoX/VkgENZN7AmOZV1wZalcwBSVGqsJqtvkUnkEYtjCqGgprS3gSKtRgG8NWlEE9o3FsWrGD/WSxuEY3MIrMDYdMDG9oZ9S4hRGme+JKEXWHo4AQoivDR+IZNd3CFAdrsrApihJiGkxgHyDFwPCZdkaNGYkxxeEssRMXa+LatH8pOOSMjWGHpusTU8Xy0AlOh0JUamkL5XXHcP/GYJEzFoZEe1SpI8SXHjx1uqePhrj+DOEm6QhGfdijOIUFucIyDDwEjTFhqphRGz/o8CwtMcJktQ2JLXWIa09E2ICeDAbLmxRcS2FKKnmDwW8aw+A9kWJPKbQAGxUcRvcIuAfcJWoKU8qFgNAQ2wxoFEMtwvbYQkNe0Bs8FlsKNBLV8SirlFAcYstRwHZI0WhinarsjfUH/uCSpHhEmLyFseDqwmWTpGiXF/0W4olPCnyGftqB9QWTBSmfqohabAyxam+PBnIZejqNDN9aWTMQdUiL4o+2EMvskhAey58BUYfX1CEPphISAni8+xF0ZXFC3kI2r4Ih4ZRBX9wStc2BOrYiAAyh7gl0Dz8nt2ABo5xhvIa67xSgKswxRF8wXkN9nAs1wMZoz7BFaFJogoYuZ9hc34jzGh5pa/f1/kZHGHoLKODznPQwVNVv1BhA0RLo9gWfUapbNL/pylBtIwwAw4jhKbRafboyXOVThjwppzG0tcnKsPiBPCkVPPmKFJpjQT+k+aF8d/B5v0uX6tpkScoXB45YLRqtQPgreIZ84XzEKKWre7yqmQg+UarpCnIEqsB5SBltNu2Qkn1fvkh3CrZo97268lcIk6Zgi9EwGjSMvm/ElhlF/IorQsPBCPIcrlCw2d26e/9BvYY1RnXPqA61Tgv6NeQLBKcILuyeQluZrA1jtoTTCFy+kx7sJkdoGKOIKbjyanrekOw56cXZCqobzT/7R0d/78/2HPqsmMJQmjKE7Zt+yAt1X8ipwEYeSSaGekcXWdAsY9XL2fPq+vvd3h/AZJbqC79SBY0tTrqBv3fs3NbHwsMQqaKhppxsrqE5HGFpgmixMERaRztEi8Zs0Py0vTjO3IHMwhBbnipKjUG2HEd23xQiZ2GIzcOg2mwmXZGr1m4NPcjE+RAS0IpL+3xqI0y6wkVe4BQ5JA02SaFOFDQG59fJMHlDDyoDQ3QuO1VZ4H6Fo22J2B0sGh+dSkO1u9GEjLMDhN2XcIZ43TOxPSYuIWtV3eMQiF4Mt7xxe0KbOOmGEjZyzSeUpMuEYO/JMBGSGEnErqHXMdMncwR7wAYtRDRpkGvoOUtGKzQPjWKYppUfk1IWmDZ893wi9ZwGRqJuDQSJRhuiDb1FoTahMoyh8V06PVJDc00zSgk7oPqqHoN0dZhfwvJAYsjTXa4sEVTyZfY8SQx135AkCJWOiFYAQUtrOo2hVoBBy6rI9mmAUWN7sQWJoVYlRGyok3/5AJVvi3KRGGqJUeqwHGkRurqwzrcmNeOp+p7cEymbp9SiryMbQZI+1Ir1yE0Ssu1GPQn2SOwxoW+7qNQn0Gf/yXq6RVsjZwAGxS5V2yuIT5ZCUtQ0/ylvejfFt1AETVClD9TUNNs7b1rSHcE/VPKGQa6rpDAoC+ROniMk8dWpiLa3g+dC0tUEuyF/xiUhTqNYNIF+HRSE/uE2hxH62lsl8qEknQIjudAT9terDiPLCIWXSgQjyOlZkuwab5nl9IJV/yJ9uSM2eMYDPKaeF9Ft9Lq/2SbXCQWnG+Bj+rkXju9y9q4Xipclmy24VgsKCy+p5fqiDu8MqVz4zFDnA6WFj/HtOkfXO3Ehi1KGbAPU2S33jzmPzq/nvl5TgSxKw8aojgC9O3cvOHcsYgbf6lKpY5Sl+hw+jetnXMcEp/AVNZJVylKqBS+iY8+F1+s4fbNPq9Aq5UhNS70Dbj+Z3ztIDvwYxhX44SCrewopheHyAd/3jvldRCmgz9ME8g6fxiG07P1iNb+LKEUSmcZyQRMi/5j6vznOz4GSlAVTtZ2UhuIn6OleSMqCqdtMalPKEV6kd/95RRSlWClTA4Ekaux2IO2FY16RDJiU4eo2k0eN2lKtecOBDah6jG2RXkjFJGiU6L4lskV+s6FHd540L4mtf16OoRv/zMmlR+EhTaV+vBYXQ9lPMKnEkPfguocyJN+JwbEYQ3YU8HTrkUvUyYgn5+HWUllpaBBqBul+/UT7gd/DRje4O4mw8ZdvQgC0pHF9GPwKXOcUFFT4ATknBVlMaQtv6A58PWyCtusxhQqfbwbCrN2shf8/x7u2bxwVBvR/+ebjTcJmhhLxXyzTU1yH60KThmG8/xTpcj8M8WCiHaPBcRNXwUcYx8kkhlUL/59bprfBu26iNPCZcY5F1WQenfPN94mOXRxhqeeQJYRhh09ILRdOLV5SDGPu/H65vx7OCU8O1qlktM2bIOsGjuAwB1qK0syX3znzBqY4yVf7sNCEcdqKjlu6p2RD/utzYOksn9Gmg/baaQfkdszCUhrGeTIKNoMcJSte884pbBxla6BXsJ/peEZlOAX6uhTIELgW82F4m4UWL5p7DX5x82CPLMIqBbY4FARwkzZ2dprrwX6hhvqa9SpC52kODCU3sBE1qoc7/FfS/t7KeTJ8U9zcZnT+Hs1DqFpLF2ClCS/DfW0CWXN9fXudy3WScGWhCN1DTobnmI/UPGx65XrdcWNW/HNheNucg4Fmx4OprFZqJWHSFpvzsc9y8GLwFdkZ3m9/+vbZKUoMg622/UPnqp854AU9qFLmKczy/rU9P+PTDT3MRJUYRg1qC8hb42JRhxPiBlEaMsPkKu55N5PsN+ZgphDR0a0blWGK9e0z2zATgL9nextz8BYCMBCqjYoxTLG7vtM6t2Si3s8OL7e+wsFU8fq84sZwgt2tjZ29w2bj7M/m5uafs7Nmc297Y32RAjMX9Qf5pOYw/JZ4EqV/nGH0OgTb+E8yTGUqeIs959DZr4P27Db+qwwTvfE85vjvMoyi7nIl5fgPM4zqHZFw/JcZRlG1WxC8Q1m/IAYffO/r+Az8D93bYitVpONHAAAAAElFTkSuQmCC\">\nRackspace Monitoring</h1>",
+      "content": "<link href=\"https://fonts.googleapis.com/css?family=Fira+Sans\" rel=\"stylesheet\">\n<div style=\"\">\n<h1 style=\"color: #000000;font-family: 'Fira Sans', sans-serif;font-style: italic;\">\n<img style=\"vertical-align:baseline;\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAA8CAYAAAAgwDn8AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4wMHEgw0FNBNQgAABC1JREFUaN692k1sFVUYxvFfoRWsWASpBT8AEYq0CzUujAuXuiUxLowrExONURd+xuhGV7p1Zdy4wcS4NNGFG2M0LnQDGlssKgVpIeVDiIipIq2LM0Onlzv348yZeZKbzG1uz3n+c+a9533fcwf0oDMrlwPZK0bLWB7tPH5RW3APHsT9GMdW3IihbLyTg30YWIfXMIGlCPMf4JsuxodwH/bj4cz0SMlNG8BcPwA340ns6tM8XMaHHcwP4iE8jUewucdxD3UFKEx0h7CsMTqF2RLze/AyHsfGPsb8Dwf7WYFx4fmL0XGcbjG/Bo/hLeyLGPMipvsBmBQfwDO4VHg/jFfxCjZEjrmA2V4BhiLvUq7pwvUI3sEzWFthzFmc7RXgJtwVOdE/OJxd34B38WwF47kOY3FNp0+sW7m8DdsiJ/oDR4XH73XhzqfQNCGQSjW3crlHf98QrcOcwhN4qducPeqSEFc9DzYh/nn9GTvxthC8KXQav/cKsDYDiNVRvCg+htrpOM72CjCC3ZETLQrx82hC84RV/btXgG24PXKiK0JOExs/ZZrKL0oBCjvmLmyKnGgYOxKbXxRWoDNAQRPCRhaj2J27k87hGIwKWWA3A1UCuKqWhFR8wMrNnhPSCHoA2CAkcU1oUUgPpnAkM3pB2MkHMy9jmFfIq7oBjGF7zcbn8Bk+xSEh/K70+s9tAQoBfKdQyNShP3EA7wtpwXK7D+UlaEnZ2XUF7sb6Gsz/hDfwuZbydLTkH8r+3g1gsgbzX+E5q1PsUoPd1AlgGHsTm/8aTwnpRSXjuTrtA1uEJCyVZvBCSvNtAQrBsiPRHPAX3sSPKc23BShor1BBpdBHwtdkUvPdAFIF8DG8J7RBkprvBLBOtSK+qAMKyVdqlQFsFjaxqprHx/mb1Hf/GoCWLtxYgvG/kNWuz9dg/hqAgvKmahX9KwTuEnzSMMCE6rn8r/i+Jt8dAQalqQG+k+XtdTz7nQA2SdNB+FZJhlk3wK3iu3C5LuCHus2vAih8A+0WeqFVNC9rPNX5+KwCKKhKFy7Xbzhfs/e2AGukCeBp4VipcYCNQiO3ipa1FCtNAmwV34XLdVHoKjQHkKgLl2sBJ6g/gK8CFLQP11Ucc1bonjWiIsCANDXAYaEZ1ThAqi7cVPUh4gBuUb0Ld/XopzGAli5c7El8rjPC6UkjAczqFUjRhTuuvAtYO0CKHXhGdvTTNMD1wgpUVaMBXARI0YVbdfTTNECKLtw52U9qmgrgIsC4+F+N5DqhcPTTNECKHfiIkMg1DrBemgAuPWWpG2CL6l24yxqsAVoBdgp1QBWdl/X9mwxgQg9oUvxv4XLNZ6+223CdUIO4V/ezsm76RWgIP5AxLAjt9LU4WaP/qwBVNSXEwXahrt6fAXzZBEDVIn5JyIGWhY1sCAeF9LxW8/A/hW/Bj2kw/ZYAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMDdUMTc6MTI6NTIrMDE6MDDIefMoAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTA3VDE3OjEyOjUyKzAxOjAwuSRLlAAAAABJRU5ErkJggg==\" alt=\"\" />\nmonitoring\n</h1>\n<div>",
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -301,7 +301,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "usage_user",
           "value": "usage_user"
         },
@@ -327,7 +326,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "aaaaaa",
           "value": "aaaaaa"
         },
@@ -353,8 +351,9 @@
       {
         "allValue": null,
         "current": {
-          "text": "development:0",
-          "value": "development:0"
+          "isNone": true,
+          "text": "None",
+          "value": ""
         },
         "datasource": "InfluxDB",
         "definition": "SHOW TAG VALUES ON \"salus\" WITH KEY = \"resourceId\" WHERE \"account\" = $tenant",
@@ -409,5 +408,5 @@
   "timezone": "",
   "title": "Detailed",
   "uid": "vZWyTBXmz",
-  "version": 12
+  "version": 16
 }

--- a/dev/kapacitor-event-ingest/grafana-dashboards/Detailed.json
+++ b/dev/kapacitor-event-ingest/grafana-dashboards/Detailed.json
@@ -1,0 +1,399 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "InfluxDB",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Events",
+        "query": "SELECT message FROM \"autogen\".\"event\" WHERE $timeFilter AND \"account\" = '$tenant' AND \"resourceId\" = '$resource'",
+        "showIn": 0,
+        "tags": [],
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "iteration": 1551820596469,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "account"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "resourceId"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "/^$measurement$/",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean($field) FROM \"autogen\"./^$measurement$/ WHERE (\"account\" =~ /^$tenant$/ AND \"resourceId\" =~ /^$resource$/) AND $timeFilter GROUP BY time($__interval), \"account\", \"resourceId\" fill(previous)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "/^$field$/"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "account",
+              "operator": "=~",
+              "value": "/^$tenant$/"
+            },
+            {
+              "condition": "AND",
+              "key": "resourceId",
+              "operator": "=~",
+              "value": "/^$resource$/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$measurement used",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [],
+      "datasource": "InfluxDB",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "groupBy": [],
+          "hide": false,
+          "measurement": "event",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT * FROM \"autogen\".\"event\" WHERE $timeFilter AND \"account\" = '$tenant'",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "message"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "account",
+              "operator": "=",
+              "value": "tenant-01"
+            },
+            {
+              "condition": "AND",
+              "key": "resourceId",
+              "operator": "=",
+              "value": "resource-003"
+            }
+          ]
+        }
+      ],
+      "title": "Events",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "cpu",
+          "value": "cpu"
+        },
+        "datasource": "InfluxDB",
+        "definition": "show measurements",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "measurement",
+        "options": [],
+        "query": "show measurements",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "usage_user",
+          "value": "usage_user"
+        },
+        "datasource": "InfluxDB",
+        "definition": "SHOW FIELD KEYS FROM $measurement",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "field",
+        "options": [],
+        "query": "SHOW FIELD KEYS FROM $measurement",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "aaaaaa",
+          "value": "aaaaaa"
+        },
+        "datasource": "InfluxDB",
+        "definition": "SHOW TAG VALUES ON \"salus\" WITH KEY = \"account\"",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "tenant",
+        "options": [],
+        "query": "SHOW TAG VALUES ON \"salus\" WITH KEY = \"account\"",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "development:0",
+          "value": "development:0"
+        },
+        "datasource": "InfluxDB",
+        "definition": "SHOW TAG VALUES ON \"salus\" WITH KEY = \"resourceId\" WHERE \"account\" = $tenant",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "resource",
+        "options": [],
+        "query": "SHOW TAG VALUES ON \"salus\" WITH KEY = \"resourceId\" WHERE \"account\" = $tenant",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Detailed",
+  "uid": "vZWyTBXmz",
+  "version": 10
+}

--- a/dev/kapacitor-event-ingest/grafana-dashboards/Overview.json
+++ b/dev/kapacitor-event-ingest/grafana-dashboards/Overview.json
@@ -1,0 +1,257 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "iteration": 1551825566026,
+  "links": [],
+  "panels": [
+    {
+      "content": "<h1 style=\"text-align:center\"><img style=\"height:50px\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAyVBMVEX///8AAADFACLCAADFACDEABzEABrEABbEABPDABDDAAnAAADDABXV1dX5+fnDAAz98/Xp6el6enrIyMhVVVXc3Nynp6e1tbXy8vLi4uKdnZ0uLi5QUFD67O6Pj4+WlpYeHh6Dg4P34+baeYPxz9Por7VsbGxdXV3CwsK4uLjcg4zLLkHVZXDuwsfei5MMDAzmqa89PT1mZmbjnKMhISHRSlrSVWLuw8jXbnfjnqXHEy3qtrvKJzvNPU312d0XFxdCQkLMNkbTXGfzkBoDAAAQAklEQVR4nN1daUMaPRBeyYKCChTPakXB+yhqqYiC1/v/f9S7y7WTZJJNJoNony/9UAn7kGTumY2iBWN7/+h2aYyjv/fnjdbe5caP6qKfihHbSyj2N5uXPxf9bCwwEJxg83Dju+/mpZXgCO+HW4t+ygBc5BNM8dbaWPSTErHhRnCE1nfcyXUPggnutxf9wL746UcwReNbidddf4IJztcX/dzOqB6RGC4t/fouHO+JBNN9/BZn9ZxOMEFjd9HPn4tGEMEEX12u7oUSTHTHl9aPO8kT3u6/n7Wae9s7FxsjXOxs7zVb5/d/nTk2F03Dgp2NH+aLVP2xfnl4tu9Acf9bSBwztrYbufv51W9jPnYvc0TSn0U/IQe2Dm2q8/abn9QJfh6+mTl+V8dKxfqZkeLeop/Ninr7JMHg9PT0d/Lva9sSs9g9NFFsfd7zOqP+Ong6/u8lFipWa8Nev3v6eoB+bNtwWM8++fHtaA86vUJFiMrKcjGOCyriuLRWS6gWep3fCE1D4Or883mgqD92eiUhyiWEmU60LMSwf9pWF2miFH8tgo+M6knnWohaKZebxHNNiOerE3mlXdQt2VwMrSkO7nplUS56sZuxLIti/1FaDo3QLVD3t7vD1coyiV22lZWrV7Bk9Q9CsbEYegfda1ErBrDLdrIH191BKC5AL1YHD6LCQG+EWkda+yfifFx8Mr/X47IoMdFLNlEoUhUzVj/VRh28iJX8u+d+O0sv8vqoz3H7aWmcereQu33FtUTtOxMsiIH0DYZ8wCfpjIMrUbFuTpySu+4/PR6cuMrYuCx9RRUn+DnSpt0XZetjVxJT5W4s+9vC9ZiWr6QvMcci5x6fOujnXT/xNDM36wVnQSvLGUvW8Wi+/OpXueJFdLM/Hy67ElyWlKE14zFXV6pbq+WdutpN9ue9sivBgpDMtk0bw6X5pTUGsV2+pCgNs7+/cpekxWv4RZg9A/B3TvxeXxykRlzJrtPAR1Wcgm/6YSc4J3laPXYyX1Z/zz7hLkaTH6YIv8t+RlPMIW0zWK45bQUQ+UMPg048ge/KOaMp2IMaBz23/VgGhlff6ScZIy4BY8wpc8ysFO+Em9CPy/XZZ/RLGBeNDnIFKBi3vCNrTKP+4HqhRHYJ64rWLAlR+xgKgRoAsQBf51iAw6gxBo4bKF/C3prM7+F0ZOc8XmMaEt5Coz06t03sO0vE0gf8WaQtesgCFA9r2gfjIriFzqljpk18fXaWF7HIgp/SGV0p/gYrVnWPUdxl/+1eYsQTQL3D7w0KqLP74CyKXl1a86mi/jQF8L/u+WEWd//GQ2evAHP0JDujsegoi7ZVIQs9X2PiAkF45K09pGq065muj+EJnECVsuD65pprEkIDGideQSboGpzOdimWzM0JhvLJFyDgnW+uQQQmwLseJzRxmY7BR7OcBbKDyQ5LDNf+y/7HURVOsR9E8NiLoCQsnmZbKK6wpZ/hylACR5Y0MIoQWfPg4fikjwlOWnX226z00LWl364CBBGec7KA7uzXh+6++egx4V51ptogLtSxxSVZCjffT8ykOKISbBecoyvaY0bVmXktTtDVTyFDYMlSKv2Ids2rh5rXqdxNCZT7+PI34OdbA+fYs2B6BFpV2IkvQZnK1CiLV9AzGlVBqEcSMy5FYCreKAR/ewnRgmI3Jx+fbuwTvj60yaEycXDsERCkqTdBJd3w3+QMKjH6DB+ZHQEjAhGJIEHp+xOUI7kH089XDFsomazgjHprijG8HQx/gtJjJpbQRFXENfwWRg/ZFsIzSqvqTzB3glIIP8pszjWDIH3MtnAFmGv0kmm/iNSJP8His7TCTJtDPQfxPJPTRWgP+Cv7Kbwu4qs/QVWrT71bKbQEMLN3kr+AlRdY4YUbfAKnbYeUtYq1G3mN6S0rPRh+w+yngZJoi0zQRyPWn/1rDmIhy5OZ0b1yjH5FFqKpSPf0F52hR3zfPdOXQREzmSqoYH4hCLNJmpBkr83gbJp6ZPqyLXxWFulOwx5K0cEY/dkZLcbS3vt59gp2HAkee/mDUx6qwJwZ1RjDLJkIM3BR4Ba6+oh3FIJq/Qvw3pFTCgiuygI45Ba6WjUERajK+xT1WYXGmiZpbkB0St76sC1cOnIheEDQE7qmAEap7BOn3F8yRbiqnOCgW7jkZrddE8SoapCmAPEJ+SIOKsvZxxSCAbpwjB/5BPtqmN0JNT2OBv2GUsa/DdKrGsEAc2aCfHVxSpEyiTzUnQfAsFAsTULEjzcgO6cTJPRCK8htN/GpJwBY7epLncgptefjq6veMsw+FuWimRTBfZj5trdPPQF4/hhJGig5l3ilXJbK9pZXVOnrnA+14DCH4DHpEuLh+gP7cah96AfbJ9dkQE687XGVRFDVBhPYmixioWmXBLf5DPJgN2rqxAJ7LKUUyaFQBUV012kBNhn2HoX/VkgENZN7AmOZV1wZalcwBSVGqsJqtvkUnkEYtjCqGgprS3gSKtRgG8NWlEE9o3FsWrGD/WSxuEY3MIrMDYdMDG9oZ9S4hRGme+JKEXWHo4AQoivDR+IZNd3CFAdrsrApihJiGkxgHyDFwPCZdkaNGYkxxeEssRMXa+LatH8pOOSMjWGHpusTU8Xy0AlOh0JUamkL5XXHcP/GYJEzFoZEe1SpI8SXHjx1uqePhrj+DOEm6QhGfdijOIUFucIyDDwEjTFhqphRGz/o8CwtMcJktQ2JLXWIa09E2ICeDAbLmxRcS2FKKnmDwW8aw+A9kWJPKbQAGxUcRvcIuAfcJWoKU8qFgNAQ2wxoFEMtwvbYQkNe0Bs8FlsKNBLV8SirlFAcYstRwHZI0WhinarsjfUH/uCSpHhEmLyFseDqwmWTpGiXF/0W4olPCnyGftqB9QWTBSmfqohabAyxam+PBnIZejqNDN9aWTMQdUiL4o+2EMvskhAey58BUYfX1CEPphISAni8+xF0ZXFC3kI2r4Ih4ZRBX9wStc2BOrYiAAyh7gl0Dz8nt2ABo5xhvIa67xSgKswxRF8wXkN9nAs1wMZoz7BFaFJogoYuZ9hc34jzGh5pa/f1/kZHGHoLKODznPQwVNVv1BhA0RLo9gWfUapbNL/pylBtIwwAw4jhKbRafboyXOVThjwppzG0tcnKsPiBPCkVPPmKFJpjQT+k+aF8d/B5v0uX6tpkScoXB45YLRqtQPgreIZ84XzEKKWre7yqmQg+UarpCnIEqsB5SBltNu2Qkn1fvkh3CrZo97268lcIk6Zgi9EwGjSMvm/ElhlF/IorQsPBCPIcrlCw2d26e/9BvYY1RnXPqA61Tgv6NeQLBKcILuyeQluZrA1jtoTTCFy+kx7sJkdoGKOIKbjyanrekOw56cXZCqobzT/7R0d/78/2HPqsmMJQmjKE7Zt+yAt1X8ipwEYeSSaGekcXWdAsY9XL2fPq+vvd3h/AZJbqC79SBY0tTrqBv3fs3NbHwsMQqaKhppxsrqE5HGFpgmixMERaRztEi8Zs0Py0vTjO3IHMwhBbnipKjUG2HEd23xQiZ2GIzcOg2mwmXZGr1m4NPcjE+RAS0IpL+3xqI0y6wkVe4BQ5JA02SaFOFDQG59fJMHlDDyoDQ3QuO1VZ4H6Fo22J2B0sGh+dSkO1u9GEjLMDhN2XcIZ43TOxPSYuIWtV3eMQiF4Mt7xxe0KbOOmGEjZyzSeUpMuEYO/JMBGSGEnErqHXMdMncwR7wAYtRDRpkGvoOUtGKzQPjWKYppUfk1IWmDZ893wi9ZwGRqJuDQSJRhuiDb1FoTahMoyh8V06PVJDc00zSgk7oPqqHoN0dZhfwvJAYsjTXa4sEVTyZfY8SQx135AkCJWOiFYAQUtrOo2hVoBBy6rI9mmAUWN7sQWJoVYlRGyok3/5AJVvi3KRGGqJUeqwHGkRurqwzrcmNeOp+p7cEymbp9SiryMbQZI+1Ir1yE0Ssu1GPQn2SOwxoW+7qNQn0Gf/yXq6RVsjZwAGxS5V2yuIT5ZCUtQ0/ylvejfFt1AETVClD9TUNNs7b1rSHcE/VPKGQa6rpDAoC+ROniMk8dWpiLa3g+dC0tUEuyF/xiUhTqNYNIF+HRSE/uE2hxH62lsl8qEknQIjudAT9terDiPLCIWXSgQjyOlZkuwab5nl9IJV/yJ9uSM2eMYDPKaeF9Ft9Lq/2SbXCQWnG+Bj+rkXju9y9q4Xipclmy24VgsKCy+p5fqiDu8MqVz4zFDnA6WFj/HtOkfXO3Ehi1KGbAPU2S33jzmPzq/nvl5TgSxKw8aojgC9O3cvOHcsYgbf6lKpY5Sl+hw+jetnXMcEp/AVNZJVylKqBS+iY8+F1+s4fbNPq9Aq5UhNS70Dbj+Z3ztIDvwYxhX44SCrewopheHyAd/3jvldRCmgz9ME8g6fxiG07P1iNb+LKEUSmcZyQRMi/5j6vznOz4GSlAVTtZ2UhuIn6OleSMqCqdtMalPKEV6kd/95RRSlWClTA4Ekaux2IO2FY16RDJiU4eo2k0eN2lKtecOBDah6jG2RXkjFJGiU6L4lskV+s6FHd540L4mtf16OoRv/zMmlR+EhTaV+vBYXQ9lPMKnEkPfguocyJN+JwbEYQ3YU8HTrkUvUyYgn5+HWUllpaBBqBul+/UT7gd/DRje4O4mw8ZdvQgC0pHF9GPwKXOcUFFT4ATknBVlMaQtv6A58PWyCtusxhQqfbwbCrN2shf8/x7u2bxwVBvR/+ebjTcJmhhLxXyzTU1yH60KThmG8/xTpcj8M8WCiHaPBcRNXwUcYx8kkhlUL/59bprfBu26iNPCZcY5F1WQenfPN94mOXRxhqeeQJYRhh09ILRdOLV5SDGPu/H65vx7OCU8O1qlktM2bIOsGjuAwB1qK0syX3znzBqY4yVf7sNCEcdqKjlu6p2RD/utzYOksn9Gmg/baaQfkdszCUhrGeTIKNoMcJSte884pbBxla6BXsJ/peEZlOAX6uhTIELgW82F4m4UWL5p7DX5x82CPLMIqBbY4FARwkzZ2dprrwX6hhvqa9SpC52kODCU3sBE1qoc7/FfS/t7KeTJ8U9zcZnT+Hs1DqFpLF2ClCS/DfW0CWXN9fXudy3WScGWhCN1DTobnmI/UPGx65XrdcWNW/HNheNucg4Fmx4OprFZqJWHSFpvzsc9y8GLwFdkZ3m9/+vbZKUoMg622/UPnqp854AU9qFLmKczy/rU9P+PTDT3MRJUYRg1qC8hb42JRhxPiBlEaMsPkKu55N5PsN+ZgphDR0a0blWGK9e0z2zATgL9nextz8BYCMBCqjYoxTLG7vtM6t2Si3s8OL7e+wsFU8fq84sZwgt2tjZ29w2bj7M/m5uafs7Nmc297Y32RAjMX9Qf5pOYw/JZ4EqV/nGH0OgTb+E8yTGUqeIs959DZr4P27Db+qwwTvfE85vjvMoyi7nIl5fgPM4zqHZFw/JcZRlG1WxC8Q1m/IAYffO/r+Az8D93bYitVpONHAAAAAElFTkSuQmCC\">\nRackspace Monitoring</h1>",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "account"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "resourceId"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "/^$measurement$/",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean($field) FROM \"autogen\".$measurement WHERE $timeFilter GROUP BY time($__interval), \"account\", \"resourceId\" fill(linear)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "used"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$measurement : $field",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "cpu",
+          "value": "cpu"
+        },
+        "datasource": "InfluxDB",
+        "definition": "SHOW measurements",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "measurement",
+        "options": [],
+        "query": "SHOW measurements",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "usage_user",
+          "value": "usage_user"
+        },
+        "datasource": "InfluxDB",
+        "definition": "SHOW FIELD KEYS FROM $measurement",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "field",
+        "options": [],
+        "query": "SHOW FIELD KEYS FROM $measurement",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Overview",
+  "uid": "RVbtpEXmz",
+  "version": 10
+}

--- a/dev/kapacitor-event-ingest/grafana-dashboards/Overview.json
+++ b/dev/kapacitor-event-ingest/grafana-dashboards/Overview.json
@@ -9,18 +9,29 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "InfluxDB",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Events",
+        "query": "SELECT message FROM \"autogen\".\"event\" WHERE $timeFilter",
+        "showIn": 0,
+        "tags": [],
+        "type": "tags"
       }
     ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
-  "iteration": 1551825566026,
+  "id": 3,
   "links": [],
   "panels": [
     {
-      "content": "<h1 style=\"text-align:center\"><img style=\"height:50px\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAyVBMVEX///8AAADFACLCAADFACDEABzEABrEABbEABPDABDDAAnAAADDABXV1dX5+fnDAAz98/Xp6el6enrIyMhVVVXc3Nynp6e1tbXy8vLi4uKdnZ0uLi5QUFD67O6Pj4+WlpYeHh6Dg4P34+baeYPxz9Por7VsbGxdXV3CwsK4uLjcg4zLLkHVZXDuwsfei5MMDAzmqa89PT1mZmbjnKMhISHRSlrSVWLuw8jXbnfjnqXHEy3qtrvKJzvNPU312d0XFxdCQkLMNkbTXGfzkBoDAAAQAklEQVR4nN1daUMaPRBeyYKCChTPakXB+yhqqYiC1/v/f9S7y7WTZJJNJoNony/9UAn7kGTumY2iBWN7/+h2aYyjv/fnjdbe5caP6qKfihHbSyj2N5uXPxf9bCwwEJxg83Dju+/mpZXgCO+HW4t+ygBc5BNM8dbaWPSTErHhRnCE1nfcyXUPggnutxf9wL746UcwReNbidddf4IJztcX/dzOqB6RGC4t/fouHO+JBNN9/BZn9ZxOMEFjd9HPn4tGEMEEX12u7oUSTHTHl9aPO8kT3u6/n7Wae9s7FxsjXOxs7zVb5/d/nTk2F03Dgp2NH+aLVP2xfnl4tu9Acf9bSBwztrYbufv51W9jPnYvc0TSn0U/IQe2Dm2q8/abn9QJfh6+mTl+V8dKxfqZkeLeop/Ninr7JMHg9PT0d/Lva9sSs9g9NFFsfd7zOqP+Ong6/u8lFipWa8Nev3v6eoB+bNtwWM8++fHtaA86vUJFiMrKcjGOCyriuLRWS6gWep3fCE1D4Or883mgqD92eiUhyiWEmU60LMSwf9pWF2miFH8tgo+M6knnWohaKZebxHNNiOerE3mlXdQt2VwMrSkO7nplUS56sZuxLIti/1FaDo3QLVD3t7vD1coyiV22lZWrV7Bk9Q9CsbEYegfda1ErBrDLdrIH191BKC5AL1YHD6LCQG+EWkda+yfifFx8Mr/X47IoMdFLNlEoUhUzVj/VRh28iJX8u+d+O0sv8vqoz3H7aWmcereQu33FtUTtOxMsiIH0DYZ8wCfpjIMrUbFuTpySu+4/PR6cuMrYuCx9RRUn+DnSpt0XZetjVxJT5W4s+9vC9ZiWr6QvMcci5x6fOujnXT/xNDM36wVnQSvLGUvW8Wi+/OpXueJFdLM/Hy67ElyWlKE14zFXV6pbq+WdutpN9ue9sivBgpDMtk0bw6X5pTUGsV2+pCgNs7+/cpekxWv4RZg9A/B3TvxeXxykRlzJrtPAR1Wcgm/6YSc4J3laPXYyX1Z/zz7hLkaTH6YIv8t+RlPMIW0zWK45bQUQ+UMPg048ge/KOaMp2IMaBz23/VgGhlff6ScZIy4BY8wpc8ysFO+Em9CPy/XZZ/RLGBeNDnIFKBi3vCNrTKP+4HqhRHYJ64rWLAlR+xgKgRoAsQBf51iAw6gxBo4bKF/C3prM7+F0ZOc8XmMaEt5Coz06t03sO0vE0gf8WaQtesgCFA9r2gfjIriFzqljpk18fXaWF7HIgp/SGV0p/gYrVnWPUdxl/+1eYsQTQL3D7w0KqLP74CyKXl1a86mi/jQF8L/u+WEWd//GQ2evAHP0JDujsegoi7ZVIQs9X2PiAkF45K09pGq065muj+EJnECVsuD65pprEkIDGideQSboGpzOdimWzM0JhvLJFyDgnW+uQQQmwLseJzRxmY7BR7OcBbKDyQ5LDNf+y/7HURVOsR9E8NiLoCQsnmZbKK6wpZ/hylACR5Y0MIoQWfPg4fikjwlOWnX226z00LWl364CBBGec7KA7uzXh+6++egx4V51ptogLtSxxSVZCjffT8ykOKISbBecoyvaY0bVmXktTtDVTyFDYMlSKv2Ids2rh5rXqdxNCZT7+PI34OdbA+fYs2B6BFpV2IkvQZnK1CiLV9AzGlVBqEcSMy5FYCreKAR/ewnRgmI3Jx+fbuwTvj60yaEycXDsERCkqTdBJd3w3+QMKjH6DB+ZHQEjAhGJIEHp+xOUI7kH089XDFsomazgjHprijG8HQx/gtJjJpbQRFXENfwWRg/ZFsIzSqvqTzB3glIIP8pszjWDIH3MtnAFmGv0kmm/iNSJP8His7TCTJtDPQfxPJPTRWgP+Cv7Kbwu4qs/QVWrT71bKbQEMLN3kr+AlRdY4YUbfAKnbYeUtYq1G3mN6S0rPRh+w+yngZJoi0zQRyPWn/1rDmIhy5OZ0b1yjH5FFqKpSPf0F52hR3zfPdOXQREzmSqoYH4hCLNJmpBkr83gbJp6ZPqyLXxWFulOwx5K0cEY/dkZLcbS3vt59gp2HAkee/mDUx6qwJwZ1RjDLJkIM3BR4Ba6+oh3FIJq/Qvw3pFTCgiuygI45Ba6WjUERajK+xT1WYXGmiZpbkB0St76sC1cOnIheEDQE7qmAEap7BOn3F8yRbiqnOCgW7jkZrddE8SoapCmAPEJ+SIOKsvZxxSCAbpwjB/5BPtqmN0JNT2OBv2GUsa/DdKrGsEAc2aCfHVxSpEyiTzUnQfAsFAsTULEjzcgO6cTJPRCK8htN/GpJwBY7epLncgptefjq6veMsw+FuWimRTBfZj5trdPPQF4/hhJGig5l3ilXJbK9pZXVOnrnA+14DCH4DHpEuLh+gP7cah96AfbJ9dkQE687XGVRFDVBhPYmixioWmXBLf5DPJgN2rqxAJ7LKUUyaFQBUV012kBNhn2HoX/VkgENZN7AmOZV1wZalcwBSVGqsJqtvkUnkEYtjCqGgprS3gSKtRgG8NWlEE9o3FsWrGD/WSxuEY3MIrMDYdMDG9oZ9S4hRGme+JKEXWHo4AQoivDR+IZNd3CFAdrsrApihJiGkxgHyDFwPCZdkaNGYkxxeEssRMXa+LatH8pOOSMjWGHpusTU8Xy0AlOh0JUamkL5XXHcP/GYJEzFoZEe1SpI8SXHjx1uqePhrj+DOEm6QhGfdijOIUFucIyDDwEjTFhqphRGz/o8CwtMcJktQ2JLXWIa09E2ICeDAbLmxRcS2FKKnmDwW8aw+A9kWJPKbQAGxUcRvcIuAfcJWoKU8qFgNAQ2wxoFEMtwvbYQkNe0Bs8FlsKNBLV8SirlFAcYstRwHZI0WhinarsjfUH/uCSpHhEmLyFseDqwmWTpGiXF/0W4olPCnyGftqB9QWTBSmfqohabAyxam+PBnIZejqNDN9aWTMQdUiL4o+2EMvskhAey58BUYfX1CEPphISAni8+xF0ZXFC3kI2r4Ih4ZRBX9wStc2BOrYiAAyh7gl0Dz8nt2ABo5xhvIa67xSgKswxRF8wXkN9nAs1wMZoz7BFaFJogoYuZ9hc34jzGh5pa/f1/kZHGHoLKODznPQwVNVv1BhA0RLo9gWfUapbNL/pylBtIwwAw4jhKbRafboyXOVThjwppzG0tcnKsPiBPCkVPPmKFJpjQT+k+aF8d/B5v0uX6tpkScoXB45YLRqtQPgreIZ84XzEKKWre7yqmQg+UarpCnIEqsB5SBltNu2Qkn1fvkh3CrZo97268lcIk6Zgi9EwGjSMvm/ElhlF/IorQsPBCPIcrlCw2d26e/9BvYY1RnXPqA61Tgv6NeQLBKcILuyeQluZrA1jtoTTCFy+kx7sJkdoGKOIKbjyanrekOw56cXZCqobzT/7R0d/78/2HPqsmMJQmjKE7Zt+yAt1X8ipwEYeSSaGekcXWdAsY9XL2fPq+vvd3h/AZJbqC79SBY0tTrqBv3fs3NbHwsMQqaKhppxsrqE5HGFpgmixMERaRztEi8Zs0Py0vTjO3IHMwhBbnipKjUG2HEd23xQiZ2GIzcOg2mwmXZGr1m4NPcjE+RAS0IpL+3xqI0y6wkVe4BQ5JA02SaFOFDQG59fJMHlDDyoDQ3QuO1VZ4H6Fo22J2B0sGh+dSkO1u9GEjLMDhN2XcIZ43TOxPSYuIWtV3eMQiF4Mt7xxe0KbOOmGEjZyzSeUpMuEYO/JMBGSGEnErqHXMdMncwR7wAYtRDRpkGvoOUtGKzQPjWKYppUfk1IWmDZ893wi9ZwGRqJuDQSJRhuiDb1FoTahMoyh8V06PVJDc00zSgk7oPqqHoN0dZhfwvJAYsjTXa4sEVTyZfY8SQx135AkCJWOiFYAQUtrOo2hVoBBy6rI9mmAUWN7sQWJoVYlRGyok3/5AJVvi3KRGGqJUeqwHGkRurqwzrcmNeOp+p7cEymbp9SiryMbQZI+1Ir1yE0Ssu1GPQn2SOwxoW+7qNQn0Gf/yXq6RVsjZwAGxS5V2yuIT5ZCUtQ0/ylvejfFt1AETVClD9TUNNs7b1rSHcE/VPKGQa6rpDAoC+ROniMk8dWpiLa3g+dC0tUEuyF/xiUhTqNYNIF+HRSE/uE2hxH62lsl8qEknQIjudAT9terDiPLCIWXSgQjyOlZkuwab5nl9IJV/yJ9uSM2eMYDPKaeF9Ft9Lq/2SbXCQWnG+Bj+rkXju9y9q4Xipclmy24VgsKCy+p5fqiDu8MqVz4zFDnA6WFj/HtOkfXO3Ehi1KGbAPU2S33jzmPzq/nvl5TgSxKw8aojgC9O3cvOHcsYgbf6lKpY5Sl+hw+jetnXMcEp/AVNZJVylKqBS+iY8+F1+s4fbNPq9Aq5UhNS70Dbj+Z3ztIDvwYxhX44SCrewopheHyAd/3jvldRCmgz9ME8g6fxiG07P1iNb+LKEUSmcZyQRMi/5j6vznOz4GSlAVTtZ2UhuIn6OleSMqCqdtMalPKEV6kd/95RRSlWClTA4Ekaux2IO2FY16RDJiU4eo2k0eN2lKtecOBDah6jG2RXkjFJGiU6L4lskV+s6FHd540L4mtf16OoRv/zMmlR+EhTaV+vBYXQ9lPMKnEkPfguocyJN+JwbEYQ3YU8HTrkUvUyYgn5+HWUllpaBBqBul+/UT7gd/DRje4O4mw8ZdvQgC0pHF9GPwKXOcUFFT4ATknBVlMaQtv6A58PWyCtusxhQqfbwbCrN2shf8/x7u2bxwVBvR/+ebjTcJmhhLxXyzTU1yH60KThmG8/xTpcj8M8WCiHaPBcRNXwUcYx8kkhlUL/59bprfBu26iNPCZcY5F1WQenfPN94mOXRxhqeeQJYRhh09ILRdOLV5SDGPu/H65vx7OCU8O1qlktM2bIOsGjuAwB1qK0syX3znzBqY4yVf7sNCEcdqKjlu6p2RD/utzYOksn9Gmg/baaQfkdszCUhrGeTIKNoMcJSte884pbBxla6BXsJ/peEZlOAX6uhTIELgW82F4m4UWL5p7DX5x82CPLMIqBbY4FARwkzZ2dprrwX6hhvqa9SpC52kODCU3sBE1qoc7/FfS/t7KeTJ8U9zcZnT+Hs1DqFpLF2ClCS/DfW0CWXN9fXudy3WScGWhCN1DTobnmI/UPGx65XrdcWNW/HNheNucg4Fmx4OprFZqJWHSFpvzsc9y8GLwFdkZ3m9/+vbZKUoMg622/UPnqp854AU9qFLmKczy/rU9P+PTDT3MRJUYRg1qC8hb42JRhxPiBlEaMsPkKu55N5PsN+ZgphDR0a0blWGK9e0z2zATgL9nextz8BYCMBCqjYoxTLG7vtM6t2Si3s8OL7e+wsFU8fq84sZwgt2tjZ29w2bj7M/m5uafs7Nmc297Y32RAjMX9Qf5pOYw/JZ4EqV/nGH0OgTb+E8yTGUqeIs959DZr4P27Db+qwwTvfE85vjvMoyi7nIl5fgPM4zqHZFw/JcZRlG1WxC8Q1m/IAYffO/r+Az8D93bYitVpONHAAAAAElFTkSuQmCC\">\nRackspace Monitoring</h1>",
+      "content": "<link href=\"https://fonts.googleapis.com/css?family=Fira+Sans\" rel=\"stylesheet\">\n<div style=\"\">\n<h1 style=\"color: #000000;font-family: 'Fira Sans', sans-serif;font-style: italic;\">\n<img style=\"vertical-align:baseline;\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAA8CAYAAAAgwDn8AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4wMHEgw0FNBNQgAABC1JREFUaN692k1sFVUYxvFfoRWsWASpBT8AEYq0CzUujAuXuiUxLowrExONURd+xuhGV7p1Zdy4wcS4NNGFG2M0LnQDGlssKgVpIeVDiIipIq2LM0Onlzv348yZeZKbzG1uz3n+c+a9533fcwf0oDMrlwPZK0bLWB7tPH5RW3APHsT9GMdW3IihbLyTg30YWIfXMIGlCPMf4JsuxodwH/bj4cz0SMlNG8BcPwA340ns6tM8XMaHHcwP4iE8jUewucdxD3UFKEx0h7CsMTqF2RLze/AyHsfGPsb8Dwf7WYFx4fmL0XGcbjG/Bo/hLeyLGPMipvsBmBQfwDO4VHg/jFfxCjZEjrmA2V4BhiLvUq7pwvUI3sEzWFthzFmc7RXgJtwVOdE/OJxd34B38WwF47kOY3FNp0+sW7m8DdsiJ/oDR4XH73XhzqfQNCGQSjW3crlHf98QrcOcwhN4qducPeqSEFc9DzYh/nn9GTvxthC8KXQav/cKsDYDiNVRvCg+htrpOM72CjCC3ZETLQrx82hC84RV/btXgG24PXKiK0JOExs/ZZrKL0oBCjvmLmyKnGgYOxKbXxRWoDNAQRPCRhaj2J27k87hGIwKWWA3A1UCuKqWhFR8wMrNnhPSCHoA2CAkcU1oUUgPpnAkM3pB2MkHMy9jmFfIq7oBjGF7zcbn8Bk+xSEh/K70+s9tAQoBfKdQyNShP3EA7wtpwXK7D+UlaEnZ2XUF7sb6Gsz/hDfwuZbydLTkH8r+3g1gsgbzX+E5q1PsUoPd1AlgGHsTm/8aTwnpRSXjuTrtA1uEJCyVZvBCSvNtAQrBsiPRHPAX3sSPKc23BShor1BBpdBHwtdkUvPdAFIF8DG8J7RBkprvBLBOtSK+qAMKyVdqlQFsFjaxqprHx/mb1Hf/GoCWLtxYgvG/kNWuz9dg/hqAgvKmahX9KwTuEnzSMMCE6rn8r/i+Jt8dAQalqQG+k+XtdTz7nQA2SdNB+FZJhlk3wK3iu3C5LuCHus2vAih8A+0WeqFVNC9rPNX5+KwCKKhKFy7Xbzhfs/e2AGukCeBp4VipcYCNQiO3ipa1FCtNAmwV34XLdVHoKjQHkKgLl2sBJ6g/gK8CFLQP11Ucc1bonjWiIsCANDXAYaEZ1ThAqi7cVPUh4gBuUb0Ld/XopzGAli5c7El8rjPC6UkjAczqFUjRhTuuvAtYO0CKHXhGdvTTNMD1wgpUVaMBXARI0YVbdfTTNECKLtw52U9qmgrgIsC4+F+N5DqhcPTTNECKHfiIkMg1DrBemgAuPWWpG2CL6l24yxqsAVoBdgp1QBWdl/X9mwxgQg9oUvxv4XLNZ6+223CdUIO4V/ezsm76RWgIP5AxLAjt9LU4WaP/qwBVNSXEwXahrt6fAXzZBEDVIn5JyIGWhY1sCAeF9LxW8/A/hW/Bj2kw/ZYAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMDdUMTc6MTI6NTIrMDE6MDDIefMoAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTA3VDE3OjEyOjUyKzAxOjAwuSRLlAAAAABJRU5ErkJggg==\" alt=\"\" />\nmonitoring\n</h1>\n<div>",
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -34,6 +45,105 @@
       "type": "text"
     },
     {
+      "columns": [],
+      "datasource": "InfluxDB",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 8,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "groupBy": [],
+          "hide": false,
+          "measurement": "event",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT * FROM \"autogen\".\"event\" WHERE $timeFilter",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "level"
+                ],
+                "type": "field"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "previousLevel"
+                ],
+                "type": "field"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "message"
+                ],
+                "type": "field"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "usage_user-0"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "Usage:User"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Events",
+      "transform": "table",
+      "type": "table"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -41,10 +151,10 @@
       "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
-        "h": 11,
-        "w": 24,
+        "h": 8,
+        "w": 8,
         "x": 0,
-        "y": 3
+        "y": 9
       },
       "id": 2,
       "legend": {
@@ -96,18 +206,19 @@
               "type": "fill"
             }
           ],
-          "measurement": "/^$measurement$/",
+          "hide": false,
+          "measurement": "cpu",
           "orderByTime": "ASC",
           "policy": "autogen",
           "query": "SELECT mean($field) FROM \"autogen\".$measurement WHERE $timeFilter GROUP BY time($__interval), \"account\", \"resourceId\" fill(linear)",
-          "rawQuery": true,
+          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "used"
+                  "usage_user"
                 ],
                 "type": "field"
               },
@@ -124,7 +235,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$measurement : $field",
+      "title": "CPU",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -140,7 +251,271 @@
       },
       "yaxes": [
         {
+          "format": "percent",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
           "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "account"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "resourceId"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "path"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "disk",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean($field) FROM \"autogen\".$measurement WHERE $timeFilter GROUP BY time($__interval), \"account\", \"resourceId\" fill(linear)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "used_percent"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "account"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "resourceId"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mem",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean($field) FROM \"autogen\".$measurement WHERE $timeFilter GROUP BY time($__interval), \"account\", \"resourceId\" fill(linear)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "used_percent"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -167,59 +542,7 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [
-      {
-        "allValue": null,
-        "current": {
-          "text": "cpu",
-          "value": "cpu"
-        },
-        "datasource": "InfluxDB",
-        "definition": "SHOW measurements",
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "measurement",
-        "options": [],
-        "query": "SHOW measurements",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "usage_user",
-          "value": "usage_user"
-        },
-        "datasource": "InfluxDB",
-        "definition": "SHOW FIELD KEYS FROM $measurement",
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "field",
-        "options": [],
-        "query": "SHOW FIELD KEYS FROM $measurement",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      }
-    ]
+    "list": []
   },
   "time": {
     "from": "now-5m",
@@ -252,6 +575,6 @@
   },
   "timezone": "",
   "title": "Overview",
-  "uid": "RVbtpEXmz",
-  "version": 10
+  "uid": "_7zNKTjmz",
+  "version": 11
 }

--- a/dev/metrics-gen/README.md
+++ b/dev/metrics-gen/README.md
@@ -23,3 +23,10 @@ gen:
 The following line chart shows an example of what would be generated from the example config:
 
 ![](docs/example-viz.png)
+
+## Ingesting raw metrics into InfluxDB
+
+The [Salus Event Engine Ingest](https://github.com/racker/salus-event-engine-ingest) application
+includes a Spring profile, `metrics-to-influx`, which configures the application to send raw
+metrics to the InfluxDB Docker compose service declared in 
+[docker-compose-influxdb.yml](../telemetry-infra/docker-compose-influxdb.yml)


### PR DESCRIPTION
# What

I thought I better source control exports of the Grafana dashboards I use for the end to end demo. There was also some docs that were good to capture for metrics ingest into InfluxDB.

The Grafana dashboards can be imported into the Docker compose service declared here
https://github.com/racker/salus-telemetry-bundle/blob/master/dev/telemetry-infra/docker-compose-influxdb.yml#L13