### PR TITLE
Added a dev-time kubernetes manifest for testing event engine discovery

### DIFF
--- a/dev/event-engine-kube/kapacitor.yml
+++ b/dev/event-engine-kube/kapacitor.yml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kapacitor
+data:
+  kapacitor.conf: |
+    data_dir = "/var/lib/kapacitor"
+    default-retention-policy = "autogen"
+
+    [alert]
+      persist-topics = true
+
+    [http]
+      bind-address = ":9092"
+
+    [[influxdb]]
+      enabled = false
+
+    [logging]
+      file = "STDOUT"
+      level = "INFO"
+
+    [config-override]
+      enabled = true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: kapacitor
+  name: kapacitor
+spec:
+  replicas: 2
+  serviceName: kapacitor
+  selector:
+    matchLabels:
+      app: kapacitor
+  template:
+    metadata:
+      labels:
+        app: kapacitor
+      annotations:
+        redeploy: "1"
+    spec:
+      containers:
+        - image: kapacitor:1.5.2
+          name: kapacitor
+          ports:
+            - containerPort: 9092
+          volumeMounts:
+            - mountPath: /var/lib/kapacitor
+              name: kapacitor-data
+            - mountPath: /etc/kapacitor
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: kapacitor
+            items:
+              - key: kapacitor.conf
+                path: kapacitor.conf
+  volumeClaimTemplates:
+    - metadata:
+        name: kapacitor-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kapacitor
+spec:
+  selector:
+    app: kapacitor
+  ports:
+    - port: 9092
+  type: ClusterIP
+  clusterIP: None

--- a/dev/event-engine-kube/monitor-grafana.yml
+++ b/dev/event-engine-kube/monitor-grafana.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: monitor-grafana
+    stack: monitor
+  name: monitor-grafana
+spec:
+  replicas: 1
+  serviceName: monitor-grafana
+  selector:
+    matchLabels:
+      app: monitor-grafana
+  template:
+    metadata:
+      labels:
+        app: monitor-grafana
+        stack: monitor
+    spec:
+      containers:
+        - image: grafana/grafana:6.0.2
+          name: grafana
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: monitor-grafana-data
+  volumeClaimTemplates:
+    - metadata:
+        name: monitor-grafana-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitor-grafana
+spec:
+  selector:
+    app: monitor-grafana
+  ports:
+    - port: 3000
+  type: LoadBalancer

--- a/dev/event-engine-kube/monitor-influxdb.yml
+++ b/dev/event-engine-kube/monitor-influxdb.yml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: monitor-influxdb
+    stack: monitor
+  name: monitor-influxdb
+spec:
+  replicas: 1
+  serviceName: monitor-influxdb
+  selector:
+    matchLabels:
+      app: monitor-influxdb
+  template:
+    metadata:
+      labels:
+        app: monitor-influxdb
+        stack: monitor
+    spec:
+      containers:
+        - image: influxdb:1.7.5
+          name: influxdb
+          ports:
+            - containerPort: 8086
+          volumeMounts:
+            - mountPath: /var/lib/influxdb
+              name: monitor-influxdb-data
+  volumeClaimTemplates:
+    - metadata:
+        name: monitor-influxdb-data
+        labels:
+          stack: monitor
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitor-influxdb
+  labels:
+    stack: monitor
+spec:
+  selector:
+    app: monitor-influxdb
+  ports:
+    - port: 8086

--- a/dev/event-engine-kube/monitor-telegraf.yml
+++ b/dev/event-engine-kube/monitor-telegraf.yml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monitor
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: monitor
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources:
+      - nodes
+      - pods
+      - persistentvolumes
+      - daemonsets.apps
+      - deployments.apps
+      - statefulsets.apps
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: monitor-role-binding
+subjects:
+  - kind: ServiceAccount
+    namespace: default
+    name: monitor
+roleRef:
+  kind: ClusterRole
+  name: monitor
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitor-telegraf
+  labels:
+    stack: monitor
+data:
+  telegraf.conf: |
+    [[inputs.kube_inventory]]
+      url = "https://kubernetes"
+      insecure_skip_verify = true
+      bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    [[outputs.influxdb]]
+      urls = ["http://monitor-influxdb:8086"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitor-telegraf
+  labels:
+    app: monitor-telegraf
+    stack: monitor
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: monitor-telegraf
+      labels:
+        app: monitor-telegraf
+        stack: monitor
+    spec:
+      serviceAccountName: monitor
+      automountServiceAccountToken: true
+      containers:
+        - name: telegraf
+          image: telegraf:1.10.1
+          volumeMounts:
+            - mountPath: /etc/telegraf
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: monitor-telegraf
+            items:
+              - key: telegraf.conf
+                path: telegraf.conf
+      restartPolicy: Always
+  selector:
+    matchLabels:
+      app: monitor-telegraf


### PR DESCRIPTION

# Resolves

Supports testing of https://jira.rax.io/browse/SALUS-191

# What

Supports the manual testing of https://github.com/racker/salus-event-engine-common/pull/3 and is referenced by the app configuration added in https://github.com/racker/salus-event-engine-ingest/pull/3 .

It also includes some additional manifest files where I researching the ability to ingest kubernetes pod state and derive grafana annotations from state transitions.