### PR TITLE
Adding repose as an optional service in apps composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ export ADMIN_API_PROFILES=secured
 export PUBLIC_API_PROFILES=secured
 ```
 
-If you had already brough up the composition, you can bring down the `public-api` and `admin-api` services
+If you had already brought up the composition, you can bring down the `public-api` and `admin-api` services
 and then re-run the `up`.
 
 Before starting the Repose services you will need to declare the Keystone/Identity credentials of 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,37 @@ to query the actuator health endpoints of the apps. The built-in [healthcheck](h
 couldn't be used since it assumes the use of `curl`, but that is purposely not installed
 in the app containers.
 
+#### Including Repose to replicate deployment-time authentication
+
+Before bringing up the app composition, declare the following two environment variables to enable
+the "secured" Spring profile of the public and admin API services:
+
+```bash
+export ADMIN_API_PROFILES=secured
+export PUBLIC_API_PROFILES=secured
+```
+
+If you had already brough up the composition, you can bring down the `public-api` and `admin-api` services
+and then re-run the `up`.
+
+Before starting the Repose services you will need to declare the Keystone/Identity credentials of 
+a service/user account that is authorized to validate authentication tokens:
+
+```bash
+export KEYSTONE_USER=...
+export KEYSTONE_PASSWORD=...
+```
+
+With that, you can run the following in the `dev/telemetry-apps` directory to start the Repose
+services each for public and admin authentication:
+
+```bash
+docker-compose -f docker-compose-repose.yml up -d 
+```
+
+**NOTE** the use of Repose for admin API authentication is not yet supported by the backend and is
+provided here for development of that capability.
+
 ### Running Event Engine with simulated metrics
 
 The Event Engine applications (`event-engine-ingest` and `event-engine-management`) can be run locally

--- a/dev/telemetry-apps/docker-compose-repose.yml
+++ b/dev/telemetry-apps/docker-compose-repose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+services:
+  repose-public:
+    image: rackerlabs/repose
+    ports:
+      - 8181:8080
+    env_file:
+      - common.env
+    environment:
+      KEYSTONE_USER: ${KEYSTONE_USER}
+      KEYSTONE_PASSWORD: ${KEYSTONE_PASSWORD}
+      BACKEND: public-api
+    volumes:
+      - ./repose-config:/etc/repose
+  repose-admin:
+    image: rackerlabs/repose
+    ports:
+      - 8282:8080
+    env_file:
+      - common.env
+    environment:
+      KEYSTONE_USER: ${KEYSTONE_USER}
+      KEYSTONE_PASSWORD: ${KEYSTONE_PASSWORD}
+      BACKEND: admin-api
+    volumes:
+      - ./repose-config:/etc/repose
+
+networks:
+  infra:
+    external: true
+    name: telemetry-infra_default

--- a/dev/telemetry-apps/docker-compose-repose.yml
+++ b/dev/telemetry-apps/docker-compose-repose.yml
@@ -4,7 +4,7 @@ services:
   repose-public:
     image: rackerlabs/repose:${REPOSE_VERSION:-9.0.0.0}
     ports:
-      - 8181:8080
+      - 8180:8080
     env_file:
       - common.env
     environment:
@@ -16,7 +16,7 @@ services:
   repose-admin:
     image: rackerlabs/repose:${REPOSE_VERSION:-9.0.0.0}
     ports:
-      - 8282:8080
+      - 8188:8080
     env_file:
       - common.env
     environment:

--- a/dev/telemetry-apps/docker-compose-repose.yml
+++ b/dev/telemetry-apps/docker-compose-repose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   repose-public:
-    image: rackerlabs/repose
+    image: rackerlabs/repose:${REPOSE_VERSION:-9.0.0.0}
     ports:
       - 8181:8080
     env_file:
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./repose-config:/etc/repose
   repose-admin:
-    image: rackerlabs/repose
+    image: rackerlabs/repose:${REPOSE_VERSION:-9.0.0.0}
     ports:
       - 8282:8080
     env_file:

--- a/dev/telemetry-apps/docker-compose.yml
+++ b/dev/telemetry-apps/docker-compose.yml
@@ -115,6 +115,8 @@ services:
       - common.env
       - etcd.env
       - services.env
+    environment:
+      SPRING_PROFILES_ACTIVE: ${PUBLIC_API_PROFILES:-}
   admin-api:
     image: ${IMG_PREFIX}salus-telemetry-api-admin
     ports:
@@ -124,6 +126,8 @@ services:
     env_file:
       - common.env
       - etcd.env
+    environment:
+      SPRING_PROFILES_ACTIVE: ${ADMIN_API_PROFILES:-}
 
 networks:
   infra:

--- a/dev/telemetry-apps/repose-config/system-model.cfg.xml
+++ b/dev/telemetry-apps/repose-config/system-model.cfg.xml
@@ -34,8 +34,7 @@
         </filters>
         <services></services>
         <destinations>
-            <!--<endpoint id="api" protocol="http" hostname="telemetry-api" root-path="/" port="8080" default="true"/>-->
-            <endpoint id="authserv" protocol="http" hostname="authserv" root-path="/" port="8080" default="true"/>
+            <endpoint id="{$ BACKEND $}" protocol="http" hostname="{$ BACKEND $}" root-path="/" port="8080" default="true"/>
         </destinations>
     </repose-cluster>
 </system-model>

--- a/dev/telemetry-apps/repose-config/system-model.cfg.xml
+++ b/dev/telemetry-apps/repose-config/system-model.cfg.xml
@@ -20,21 +20,20 @@
 
 <!-- To configure Repose see: http://www.openrepose.org/versions/8.10.0.0/index.html -->
 <system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://docs.openrepose.org/repose/system-model/v2.0 http://www.openrepose.org/versions/latest/schemas/system-model.xsd">
-    <repose-cluster id="repose">
-        <nodes>
-            <node id="repose_node1" hostname="localhost" http-port="8080"/>
-        </nodes>
-        <filters>
-            <filter name="header-normalization"/>
-            <filter name="keystone-v2"/>
-            <!-- Leaving option here for authorization filter, but Spring Security can do this -->
-            <!--<filter name="keystone-v2-authorization"/>-->
-        </filters>
-        <services></services>
-        <destinations>
-            <endpoint id="{$ BACKEND $}" protocol="http" hostname="{$ BACKEND $}" root-path="/" port="8080" default="true"/>
-        </destinations>
-    </repose-cluster>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://docs.openrepose.org/repose/system-model/v2.0 http://www.openrepose.org/versions/9.0.0.0/schemas/system-model.xsd">
+  <nodes>
+    <node id="repose_node1" hostname="localhost" http-port="8080"/>
+  </nodes>
+  <filters>
+    <filter name="header-normalization"/>
+    <filter name="keystone-v2"/>
+    <!-- Leaving option here for authorization filter, but Spring Security can do this -->
+    <!--<filter name="keystone-v2-authorization"/>-->
+  </filters>
+  <services></services>
+  <destinations>
+    <endpoint id="{$ BACKEND $}" protocol="http" hostname="{$ BACKEND $}" root-path="/" port="8080"
+      default="true"/>
+  </destinations>
 </system-model>


### PR DESCRIPTION
# What

Adds the option for running Repose each for the public and admin API containerized apps. 

This is WIP since I'm getting this error in both Repose containers when starting up:

```
2019-06-05 21:41:28,442 7248 [main] ERROR org.openrepose.commons.config.parser.jaxb.JaxbConfigurationParser - Failed to utilize the UnmarshallerValidator. Reason: cvc-complex-type.2.4.a: Invalid content was found starting with element '{"http://docs.openrepose.org/repose/system-model/v2.0":repose-cluster}'. One of '{"http://docs.openrepose.org/repose/system-model/v2.0":nodes}' is expected.
2019-06-05 21:41:28,442 7248 [main] ERROR org.openrepose.core.services.config.impl.ConfigurationServiceImpl - Configuration update error. Reason: Parsed object from XML does not match the expected configuration class. Expected: org.openrepose.core.systemmodel.config.SystemModel  -  Actual: null
```

**I'll add the following to the README after getting Repose working**

To start the apps in "repose mode" declare these two environment variables when starting the main apps compose file, for example in `dev/telemetry-apps`:

```
export ADMIN_API_PROFILES=secured
export PUBLIC_API_PROFILES=secured
docker-compose up -d
```

and then to start the Repose services, also in `dev/telemetry-apps`:

```
export KEYSTONE_USER=...
export KEYSTONE_PASSWORD=...
docker-compose -f docker-compose-repose.yml up -d 
```