### PR TITLE
Use Repose to auth tenant in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,17 +244,6 @@ in the app containers.
 
 #### Including Repose to replicate deployment-time authentication
 
-Before bringing up the app composition, declare the following two environment variables to enable
-the "secured" Spring profile of the public and admin API services:
-
-```bash
-export ADMIN_API_PROFILES=secured
-export PUBLIC_API_PROFILES=secured
-```
-
-If you had already brought up the composition, you can bring down the `public-api` and `admin-api` services
-and then re-run the `up`.
-
 Before starting the Repose services you will need to declare the Keystone/Identity credentials of 
 a service/user account that is authorized to validate authentication tokens:
 

--- a/dev/telemetry-apps/repose-config/header-normalization.cfg.xml
+++ b/dev/telemetry-apps/repose-config/header-normalization.cfg.xml
@@ -24,6 +24,7 @@
 						<header id="X-Subject-Token"/>
 						<header id="X-Subject-Name"/>
 						<header id="X-Subject-ID"/>
+						<header id="Requested-Tenant-Id"/>
 					</blacklist>
 				</target>
     </header-filters>

--- a/dev/telemetry-apps/repose-config/keystone-v2-authorization.cfg.xml
+++ b/dev/telemetry-apps/repose-config/keystone-v2-authorization.cfg.xml
@@ -3,18 +3,9 @@
                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                            xsi:schemaLocation="http://docs.openrepose.org/repose/keystone-v2/v1.0 http://www.openrepose.org/versions/latest/schemas/keystone-v2-authorization.xsd">
 
-    <tenant-handling
-            send-all-tenant-ids="true">
-
-        <validate-tenant
-                enable-legacy-roles-mode="false">
-
-            <uri-extraction-regex>.*/api/([-|\w]+)/?.*</uri-extraction-regex>
+    <tenant-handling>
+        <validate-tenant>
+            <header-extraction-name>Requested-Tenant-Id</header-extraction-name>
         </validate-tenant>
-
-        <send-tenant-id-quality
-                default-tenant-quality="1.0"
-                uri-tenant-quality="0.7"
-                roles-tenant-quality="0.5"/>
     </tenant-handling>
 </keystone-v2-authorization>

--- a/dev/telemetry-apps/repose-config/keystone-v2.cfg.xml
+++ b/dev/telemetry-apps/repose-config/keystone-v2.cfg.xml
@@ -10,6 +10,8 @@
             set-roles-in-header="true"
     />
 
+    <tenant-handling send-all-tenant-ids="true"/>
+
     <cache>
         <timeouts variability="15">
             <token>600</token>

--- a/dev/telemetry-apps/repose-config/system-model.cfg.xml
+++ b/dev/telemetry-apps/repose-config/system-model.cfg.xml
@@ -28,10 +28,10 @@
   <filters bypass-uri-regex="^/actuator.*">
     <filter name="header-normalization"/>
     <filter name="header-translation"/>
+    <filter name="url-extractor-to-header"/>
     <filter name="keystone-v2"/>
+    <filter name="keystone-v2-authorization"/>
     <filter name="merge-header"/>
-    <!-- Leaving option here for authorization filter, but Spring Security can do this -->
-    <!--<filter name="keystone-v2-authorization"/>-->
   </filters>
   <services></services>
   <destinations>

--- a/dev/telemetry-apps/repose-config/url-extractor-to-header.cfg.xml
+++ b/dev/telemetry-apps/repose-config/url-extractor-to-header.cfg.xml
@@ -1,0 +1,3 @@
+<url-extractor-to-header xmlns="http://docs.openrepose.org/repose/url-extractor-to-header/v1.0">
+    <extraction header="Requested-Tenant-Id" url-regex="/v1\.0/tenant/(\d+|[a-zA-Z]+:\d+)/.*"/>
+</url-extractor-to-header>


### PR DESCRIPTION
# What

Updates Repose to auth our new Public API url format that includes the tenant id in the request.

# How

1. Uses `url-extractor-to-header` to pluck the tenantId from the url and store it as a header value
2. Then `keystone-v2` authenticates the token provided and sends all auth'd tenants to the next step
3. `keystone-v2-authorization` picks up and validates that the tenant from the url matches the tenants found from the token

I added the new injected header to the exclusion list so that customer's can't provide it in the request themselves, but in the end I don't think this makes a difference since the filter would override it anyway.  Just seemed safer/clearer to have it there.

## How to test

I've tested in dev using `telemetry-apps` with repose.

# Why

This allows a customer who is a member of many accounts to use the same token for each of them.  They would just have to set a different tenant in the request so we know what one to return data for.

# TODO

Update the repose configs that helm uses