### PR TITLE
Add Policy Metadata requests to Insomnia

### DIFF
--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1244,7 +1244,7 @@ resources:
             "type": "local",
             "plugin": {
               "type": "disk",
-              "mountPoints": ["${rackspace.metadata.primary_mount}"]
+              "mountPoints": ["${resource.metadata.primary_mount}"]
             }
           }
         }

--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2019-10-07T21:53:30.761Z
+__export_date: 2019-10-08T20:08:02.703Z
 __export_source: insomnia.desktop.app:v6.6.2
 resources:
   - _id: req_e8b1565dab71459983d06f366d58e02b
@@ -882,12 +882,12 @@ resources:
             "monitoringZones": [
               "dev"
             ],
-              "plugin": {
-                "type": "ping",
-                "urls": [
-                  "${resource.metadata.ping_ip}"
-                ],
-                "count": 1
+            "plugin": {
+              "type": "ping",
+              "urls": [
+                "${resource.metadata.ping_ip}"
+              ],
+              "count": 1
             }
           }
         }
@@ -963,7 +963,7 @@ resources:
     isPrivate: false
     metaSortKey: -1561748362221.5
     method: GET
-    modified: 1570479247810
+    modified: 1570561739189
     name: Get tenant bound monitors
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1289,7 +1289,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360434706.1328
     method: PUT
-    modified: 1570479278764
+    modified: 1570561985425
     name: Modify selector of ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1428,7 +1428,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360416600.4531
     method: PATCH
-    modified: 1570485008834
+    modified: 1570562052224
     name: Reset Ping Monitor Defaults
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -2283,6 +2283,27 @@ resources:
     url: "{{ api_public  }}/tenant/{% prompt 'Tenant Id', 'tenantId', 'aaaaaa', '',
       false, true %}/policy-monitors"
     _type: request
+  - _id: req_01cf5de9c6b149d3b01670c6adb4895a
+    authentication: {}
+    body: {}
+    created: 1570564963226
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1564981571270.5
+    method: GET
+    modified: 1570564981622
+    name: Get monitor by id
+    parameters: []
+    parentId: fld_52f2a23df31449f6935c3be8b1a99796
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
+      false %}/monitors/{% prompt 'Monitor ID', '', '', false,      false %}"
+    _type: request
   - _id: req_ce664bb03fd641088890a6bcc6470f4c
     authentication: {}
     body: {}
@@ -2851,6 +2872,38 @@ resources:
     url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
       false %}/monitors/{% prompt 'Monitor ID', '', '', false,      false %}"
     _type: request
+  - _id: req_97d1a7f4ba5e43538bd14377e8b48f11
+    authentication: {}
+    body: {}
+    created: 1570564842656
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1570564842656
+    method: GET
+    modified: 1570564994887
+    name: Get resource by id
+    parameters: []
+    parentId: fld_0a6a98b5c25d42b2a28631f09356c466
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
+      false %}/resources/{% prompt 'resourceId', 'Resource Id',
+      '', '', false %}"
+    _type: request
+  - _id: fld_0a6a98b5c25d42b2a28631f09356c466
+    created: 1552328968587
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1552638807165
+    modified: 1556919014269
+    name: Resources
+    parentId: fld_3373074209bc49199beb8e5967f1ae4a
+    _type: request_group
   - _id: req_1480e6feddf44046ae92d6ddc0d6151b
     authentication: {}
     body: {}
@@ -2886,16 +2939,6 @@ resources:
     url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
       false %}/resources"
     _type: request
-  - _id: fld_0a6a98b5c25d42b2a28631f09356c466
-    created: 1552328968587
-    description: ""
-    environment: {}
-    environmentPropertyOrder: null
-    metaSortKey: -1552638807165
-    modified: 1556919014269
-    name: Resources
-    parentId: fld_3373074209bc49199beb8e5967f1ae4a
-    _type: request_group
   - _id: req_8cb39d8dec0c4dda9bfaeccb329839d5
     authentication: {}
     body: {}
@@ -2984,6 +3027,38 @@ resources:
       false %}/resources/{% prompt 'deletedResourceId', 'Deleted Resource Id',
       '', '', false %}"
     _type: request
+  - _id: req_7b604db998f54a19bcab67504ab7ee33
+    authentication: {}
+    body: {}
+    created: 1570564835806
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1570564835806
+    method: GET
+    modified: 1570565000875
+    name: Get event task by id
+    parameters: []
+    parentId: fld_906f0421bdb54818a4abb19bd58a8d21
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa',
+      'tenantId', false %}/event-tasks/{% prompt 'Task Id', '', '', '', false
+      %}"
+    _type: request
+  - _id: fld_906f0421bdb54818a4abb19bd58a8d21
+    created: 1552841089415
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1552638807115
+    modified: 1556919020174
+    name: Event tasks
+    parentId: fld_3373074209bc49199beb8e5967f1ae4a
+    _type: request_group
   - _id: req_6c922104397b40abaf6e624d4f7516a5
     authentication: {}
     body: {}
@@ -3014,16 +3089,6 @@ resources:
     url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa',
       'tenantId', false %}/event-tasks"
     _type: request
-  - _id: fld_906f0421bdb54818a4abb19bd58a8d21
-    created: 1552841089415
-    description: ""
-    environment: {}
-    environmentPropertyOrder: null
-    metaSortKey: -1552638807115
-    modified: 1556919020174
-    name: Event tasks
-    parentId: fld_3373074209bc49199beb8e5967f1ae4a
-    _type: request_group
   - _id: req_ff8e3b0f818e4ed8a5c8936292084b96
     authentication: {}
     body:

--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2019-09-18T23:29:56.465Z
+__export_date: 2019-10-07T15:59:43.629Z
 __export_source: insomnia.desktop.app:v6.6.2
 resources:
   - _id: req_e8b1565dab71459983d06f366d58e02b
@@ -164,6 +164,142 @@ resources:
     settingStoreCookies: true
     url: http://{{ policy_mgmt  }}/api/admin/policy/monitors/{% prompt 'Monitor
       Policy Id', 'policyId', '', '', false, false %}
+    _type: request
+  - _id: req_eeda52ec03e94f838cf8eb28b23d6fff
+    authentication: {}
+    body: {}
+    created: 1568830919962
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1568830919962
+    method: GET
+    modified: 1568830926831
+    name: Get all metadata policies
+    parameters: []
+    parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ policy_mgmt  }}/api/admin/policy/metadata/monitor"
+    _type: request
+  - _id: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
+    created: 1567560642822
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1565742372413.4375
+    modified: 1567560761406
+    name: Metadata Policies
+    parentId: fld_7876677d6cfa4e828deefa45a4aeccf5
+    _type: request_group
+  - _id: req_e4c1c28e5b44427c98d8bf96c2dbb188
+    authentication: {}
+    body: {}
+    created: 1567561570834
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1567561570834
+    method: GET
+    modified: 1567797682620
+    name: Get effective policy for tenant and monitor type
+    parameters: []
+    parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ policy_mgmt  }}/api/admin/policy/metadata/monitor/effective/{% prompt
+      'Tenant Id', 'tenantId', 'aaaaaa', '', false, true %}/{% prompt 'Target
+      Class Name', 'className', 'Monitor', '', false, true %}/{% prompt 'Monitor
+      Type', 'monitorType', 'mem', '', false, true %}"
+    _type: request
+  - _id: req_6c2a431427c0423d9f3a25cd4f253b15
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "scope": "GLOBAL",
+          "subscope": null,
+          "targetClassName": "Monitor",
+          "valueType": "DURATION",
+          "key": "interval",
+          "value": "90"
+        }
+    created: 1567560651232
+    description: ""
+    headers:
+      - id: pair_ae2092bb938c40998b29d4d8e2c43134
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1567560651232
+    method: POST
+    modified: 1568830988915
+    name: Create Policy
+    parameters: []
+    parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ policy_mgmt  }}/api/admin/policy/metadata/monitor"
+    _type: request
+  - _id: req_2ba7b9ab9c82472798594fc7a976e87b
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "value": "72"
+        }
+    created: 1568062267884
+    description: ""
+    headers:
+      - id: pair_75ff9be2626b446887e42d7358146c82
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1567560651207
+    method: PUT
+    modified: 1569342087059
+    name: Update Policy
+    parameters: []
+    parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ policy_mgmt  }}/api/admin/policy/metadata/monitor/{% prompt 'Policy
+      Id', 'policyId', '', '', false, false %}"
+    _type: request
+  - _id: req_d2059c4aa9634caf81397860d7033110
+    authentication: {}
+    body: {}
+    created: 1567634983327
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1567560651182
+    method: DELETE
+    modified: 1568062377040
+    name: Delete Policy
+    parameters: []
+    parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ policy_mgmt  }}/api/admin/policy/metadata/monitor/{% prompt 'Policy
+      Id', 'policyId', '', '', false, false %}"
     _type: request
   - _id: req_5b6ea78ad3ca460f8351d166c494ad76
     authentication: {}
@@ -448,7 +584,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555472938893
     method: POST
-    modified: 1566408996872
+    modified: 1568831054174
     name: Create testing resource
     parameters: []
     parentId: fld_b07a28e982c446ca93a8a25c01d86a74
@@ -553,7 +689,7 @@ resources:
     environment: {}
     environmentPropertyOrder: null
     metaSortKey: -1549899273935
-    modified: 1566336433141
+    modified: 1567560738189
     name: Monitor Management
     parentId: fld_29c5e645f6ff48138fd40edc4b73c9e5
     _type: request_group
@@ -728,6 +864,53 @@ resources:
     url: http://localhost:8089/api/admin/policy-monitors/{% prompt 'Policy Monitor
       Id', 'monitorId', '', '', false, true %}
     _type: request
+  - _id: req_4a7df9859b0745229a14dd8a6d73c8de
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "name": null,
+          "labelSelector": {
+            "pingable": "true"
+          },
+          "labelSelectorMethod": "AND",
+          "resourceId": null,
+          "interval": "PT1M0S",
+          "details": {
+            "type": "remote",
+            "monitoringZones": [
+                "dev"
+            ],
+            "plugin": {
+              "type": "ping",
+              "urls": [
+                "${resource.metadata.ping_ip}"
+              ],
+              "count": 1
+            }
+          }
+        }
+    created: 1568045477868
+    description: ""
+    headers:
+      - id: pair_8438b62268474888bc61402a2c954fa8
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1566022219205
+    method: PUT
+    modified: 1570463368829
+    name: Update Policy Metadata Monitor
+    parameters: []
+    parentId: fld_7b08fb62d9514da78b462d31edfa8241
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: http://localhost:8089/api/tenant/aaaaaa/monitors/e7bc277c-cc4b-4555-b71a-8ab5b19578d9
+    _type: request
   - _id: req_a23accf7a88446c9a34579699f6e8f7f
     authentication: {}
     body: {}
@@ -758,7 +941,7 @@ resources:
     isPrivate: false
     metaSortKey: -1563269766284
     method: GET
-    modified: 1566412373125
+    modified: 1568831550257
     name: Get tenant monitors
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -907,6 +1090,7 @@ resources:
           "labelSelector": {
             "pingable": "true"
           },
+          "interval": "121",
           "details": {
             "type": "remote",
             "monitoringZones": ["dev"],
@@ -925,7 +1109,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360461714
     method: POST
-    modified: 1557776354908
+    modified: 1568834843651
     name: Create ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -943,7 +1127,7 @@ resources:
       text: |-
         {
           "labelSelector": {
-            "agent_discovered_os": "darwin"
+            "pingable": "true"
           },
           "details": {
             "type": "local",
@@ -961,7 +1145,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360447430.5
     method: POST
-    modified: 1557863589717
+    modified: 1570050757958
     name: Create mem (local) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1060,7 +1244,7 @@ resources:
             "type": "local",
             "plugin": {
               "type": "disk",
-              "mountPoints": ["${resource.metadata.primary_mount}"]
+              "mountPoints": ["${rackspace.metadata.primary_mount}"]
             }
           }
         }
@@ -1073,7 +1257,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360436717.875
     method: POST
-    modified: 1558472420637
+    modified: 1567536431438
     name: Create disk (local) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1115,6 +1299,35 @@ resources:
     url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% response 'body',
       'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}
     _type: request
+  - _id: req_b9dc0976b4854e1f84bdd3469fe57b7f
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "interval": "PT3M12S"
+        }
+    created: 1567807202247
+    description: ""
+    headers:
+      - id: pair_5d055b959aa7440ab1c9d3184b9df4b1
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1555360433700.2617
+    method: PUT
+    modified: 1567807466851
+    name: Modify interval of monitor
+    parameters: []
+    parentId: fld_2cd444041994485fa243cdab9f615271
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% response 'body',
+      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}
+    _type: request
   - _id: req_fb3d9242db5442edb7823fb75383f4c1
     authentication: {}
     body:
@@ -1139,7 +1352,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360432694.3906
     method: PUT
-    modified: 1566336090057
+    modified: 1568045458589
     name: Modify details of ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -2175,6 +2388,8 @@ resources:
           "labelSelector": {
             "agent_discovered_os": "linux"
           },
+          "labelSelectorMethod": "OR",
+          "interval": 60,
           "details": {
             "type": "local",
             "plugin": {
@@ -2195,7 +2410,7 @@ resources:
     isPrivate: false
     metaSortKey: -1560651594124
     method: POST
-    modified: 1563826173212
+    modified: 1569437026419
     name: Create local monitor (disk)
     parameters: []
     parentId: fld_52f2a23df31449f6935c3be8b1a99796

--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2019-10-07T15:59:43.629Z
+__export_date: 2019-10-07T21:53:30.761Z
 __export_source: insomnia.desktop.app:v6.6.2
 resources:
   - _id: req_e8b1565dab71459983d06f366d58e02b
@@ -240,7 +240,7 @@ resources:
     isPrivate: false
     metaSortKey: -1567560651232
     method: POST
-    modified: 1568830988915
+    modified: 1570485138151
     name: Create Policy
     parameters: []
     parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
@@ -268,7 +268,7 @@ resources:
     isPrivate: false
     metaSortKey: -1567560651207
     method: PUT
-    modified: 1569342087059
+    modified: 1570485146845
     name: Update Policy
     parameters: []
     parentId: fld_5f7e60e6dcce47e78fbedf777bfe6ae0
@@ -660,7 +660,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566321774279
     method: GET
-    modified: 1566321795474
+    modified: 1570479303122
     name: Get Policy Monitor for Tenant
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -669,9 +669,9 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/{% prompt 'Tenant Id', 'tenantId',
+    url: "{{ monitor_mgmt  }}/api/tenant/{% prompt 'Tenant Id', 'tenantId',
       'aaaaaa', '', false, true %}/policy-monitors/{% prompt 'Policy Monitor
-      Id', 'policyMonitorId', '', '', false, true %}
+      Id', 'policyMonitorId', '', '', false, true %}"
     _type: request
   - _id: fld_7b08fb62d9514da78b462d31edfa8241
     created: 1566312574409
@@ -702,7 +702,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566321717634
     method: GET
-    modified: 1566321759562
+    modified: 1570479306333
     name: Get Policy Monitors for Tenant
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -711,8 +711,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/{% prompt 'Tenant Id', 'tenantId',
-      'aaaaaa', '', false, true %}/policy-monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/{% prompt 'Tenant Id', 'tenantId',
+      'aaaaaa', '', false, true %}/policy-monitors"
     _type: request
   - _id: req_d4e3842b9bfc4a088cbe6a109c6931cc
     authentication: {}
@@ -723,7 +723,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566312596095
     method: GET
-    modified: 1566312599162
+    modified: 1570479309018
     name: Get All Policy Monitors
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -732,7 +732,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/policy-monitors
+    url: "{{ monitor_mgmt  }}/api/admin/policy-monitors"
     _type: request
   - _id: req_262ca9c92c2e48839e0657322ea6ce17
     authentication: {}
@@ -743,7 +743,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566022219280
     method: GET
-    modified: 1566312584854
+    modified: 1570479311995
     name: Get Policy Monitor
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -752,8 +752,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/policy-monitors/{% prompt 'Policy Monitor
-      Id', 'monitorId', '', '', false, true %}
+    url: "{{ monitor_mgmt  }}/api/admin/policy-monitors/{% prompt 'Policy Monitor
+      Id', 'monitorId', '', '', false, true %}"
     _type: request
   - _id: req_b98f94d9dc5d44d1a54fcb4286b2dbd5
     authentication: {}
@@ -784,7 +784,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566022219255
     method: POST
-    modified: 1566491026649
+    modified: 1570479314643
     name: Create Remote Policy Monitor
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -793,7 +793,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/policy-monitors
+    url: "{{ monitor_mgmt  }}/api/admin/policy-monitors"
     _type: request
   - _id: req_ee7159e8d14f4052894d9cfbe5ee60ae
     authentication: {}
@@ -824,7 +824,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566022219242.5
     method: POST
-    modified: 1566486638879
+    modified: 1570479317602
     name: Create Local Policy Monitor
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -833,7 +833,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/policy-monitors
+    url: "{{ monitor_mgmt  }}/api/admin/policy-monitors"
     _type: request
   - _id: req_3c324287b8264f5c9a59f5053f704efd
     authentication: {}
@@ -852,7 +852,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566022219230
     method: PUT
-    modified: 1566487011102
+    modified: 1570479320231
     name: Update Policy Monitor
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -861,8 +861,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/policy-monitors/{% prompt 'Policy Monitor
-      Id', 'monitorId', '', '', false, true %}
+    url: "{{ monitor_mgmt  }}/api/admin/policy-monitors/{% prompt 'Policy Monitor
+      Id', 'monitorId', '', '', false, true %}"
     _type: request
   - _id: req_4a7df9859b0745229a14dd8a6d73c8de
     authentication: {}
@@ -880,14 +880,14 @@ resources:
           "details": {
             "type": "remote",
             "monitoringZones": [
-                "dev"
+              "dev"
             ],
-            "plugin": {
-              "type": "ping",
-              "urls": [
-                "${resource.metadata.ping_ip}"
-              ],
-              "count": 1
+              "plugin": {
+                "type": "ping",
+                "urls": [
+                  "${resource.metadata.ping_ip}"
+                ],
+                "count": 1
             }
           }
         }
@@ -900,7 +900,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566022219205
     method: PUT
-    modified: 1570463368829
+    modified: 1570479323067
     name: Update Policy Metadata Monitor
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -909,7 +909,9 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors/e7bc277c-cc4b-4555-b71a-8ab5b19578d9
+    url: "{{
+      monitor_mgmt  }}/api/tenant/aaaaaa/monitors/e7bc277c-cc4b-4555-b71a-8ab5b\
+      19578d9"
     _type: request
   - _id: req_a23accf7a88446c9a34579699f6e8f7f
     authentication: {}
@@ -920,7 +922,7 @@ resources:
     isPrivate: false
     metaSortKey: -1566022219180
     method: DELETE
-    modified: 1566315996680
+    modified: 1570479325281
     name: Delete Policy Monitor
     parameters: []
     parentId: fld_7b08fb62d9514da78b462d31edfa8241
@@ -929,8 +931,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/policy-monitors/{% prompt 'Policy Monitor
-      Id', 'monitorId', '', '', false, false %}
+    url: "{{ monitor_mgmt  }}/api/admin/policy-monitors/{% prompt 'Policy Monitor
+      Id', 'monitorId', '', '', false, false %}"
     _type: request
   - _id: req_aef343eb6916447ca8507fe2d0617d38
     authentication: {}
@@ -941,7 +943,7 @@ resources:
     isPrivate: false
     metaSortKey: -1563269766284
     method: GET
-    modified: 1568831550257
+    modified: 1570479239318
     name: Get tenant monitors
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -950,7 +952,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors"
     _type: request
   - _id: req_cd95b24220764c3b91a4b5eb79c42c93
     authentication: {}
@@ -961,7 +963,7 @@ resources:
     isPrivate: false
     metaSortKey: -1561748362221.5
     method: GET
-    modified: 1566412366924
+    modified: 1570479247810
     name: Get tenant bound monitors
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -970,7 +972,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/bound-monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/bound-monitors"
     _type: request
   - _id: req_6196f1184f20408ab3bf0e3515d8e1d3
     authentication: {}
@@ -989,7 +991,7 @@ resources:
     isPrivate: false
     metaSortKey: -1560226958159
     method: GET
-    modified: 1561066478745
+    modified: 1570479250494
     name: Get monitors by label
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -998,7 +1000,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitor-labels?size=2&page=0
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitor-labels?size=2&page=0"
     _type: request
   - _id: req_1e58c53f43c7440d8e8b4aa712d2ba10
     authentication: {}
@@ -1009,7 +1011,7 @@ resources:
     isPrivate: false
     metaSortKey: -1559139894780
     method: GET
-    modified: 1559250849470
+    modified: 1570479254263
     name: Private zone assignment counts
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1018,8 +1020,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/{% prompt 'Tenant ID', '', 'aaaaaa', '',
-      false %}/zone-assignment-counts/{% prompt 'Zone ID', '', '', '', false %}
+    url: "{{ monitor_mgmt  }}/api/tenant/{% prompt 'Tenant ID', '', 'aaaaaa', '',
+      false %}/zone-assignment-counts/{% prompt 'Zone ID', '', '', '', false %}"
     _type: request
   - _id: req_6ab953706ba64bf58f73dcf660d886b2
     authentication: {}
@@ -1038,7 +1040,7 @@ resources:
     isPrivate: false
     metaSortKey: -1557323203282.9375
     method: POST
-    modified: 1566336083734
+    modified: 1570479257315
     name: Create private dev zone
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1047,8 +1049,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/{% prompt 'Tenant ID', '', 'aaaaaa', '',
-      false %}/zones
+    url: "{{ monitor_mgmt  }}/api/tenant/{% prompt 'Tenant ID', '', 'aaaaaa', '',
+      false %}/zones"
     _type: request
   - _id: req_d1ff51844e384183a765308e41e14f39
     authentication: {}
@@ -1070,7 +1072,7 @@ resources:
     isPrivate: false
     metaSortKey: -1557172223162.25
     method: POST
-    modified: 1557945915100
+    modified: 1570479260891
     name: Create public zone (central)
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1079,7 +1081,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/admin/zones
+    url: "{{ monitor_mgmt  }}/api/admin/zones"
     _type: request
   - _id: req_14223ed2c09e4d19b3e13e17fb7b1aa2
     authentication: {}
@@ -1109,7 +1111,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360461714
     method: POST
-    modified: 1568834843651
+    modified: 1570479263711
     name: Create ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1118,7 +1120,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors"
     _type: request
   - _id: req_5706bbde1596435e886ead9e4bb23669
     authentication: {}
@@ -1145,7 +1147,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360447430.5
     method: POST
-    modified: 1570050757958
+    modified: 1570480751385
     name: Create mem (local) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1154,7 +1156,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors"
     _type: request
   - _id: req_ab1e03a9295146a9a8ef6716009221d2
     authentication: {}
@@ -1183,7 +1185,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360443859.625
     method: POST
-    modified: 1566409138454
+    modified: 1570479269301
     name: Create cpu (local) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1192,7 +1194,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors"
     _type: request
   - _id: req_f6d6c2bd148040aca7f141ed81272a03
     authentication: {}
@@ -1220,7 +1222,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360440288.75
     method: POST
-    modified: 1557946956138
+    modified: 1570479272027
     name: Create procstat (local) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1229,7 +1231,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors"
     _type: request
   - _id: req_6e0b9f057aac41ef962fa950139f90f0
     authentication: {}
@@ -1257,7 +1259,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360436717.875
     method: POST
-    modified: 1567536431438
+    modified: 1570479275679
     name: Create disk (local) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1266,7 +1268,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors"
     _type: request
   - _id: req_6aee41be94de4516bdc20756f29ac879
     authentication: {}
@@ -1287,7 +1289,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360434706.1328
     method: PUT
-    modified: 1566336091819
+    modified: 1570479278764
     name: Modify selector of ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1296,8 +1298,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% response 'body',
-      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% response 'body',
+      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}"
     _type: request
   - _id: req_b9dc0976b4854e1f84bdd3469fe57b7f
     authentication: {}
@@ -1316,7 +1318,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360433700.2617
     method: PUT
-    modified: 1567807466851
+    modified: 1570479281635
     name: Modify interval of monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1325,8 +1327,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% response 'body',
-      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% response 'body',
+      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}"
     _type: request
   - _id: req_fb3d9242db5442edb7823fb75383f4c1
     authentication: {}
@@ -1352,7 +1354,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360432694.3906
     method: PUT
-    modified: 1568045458589
+    modified: 1570479284591
     name: Modify details of ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1361,8 +1363,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% response 'body',
-      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% response 'body',
+      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}"
     _type: request
   - _id: req_285282efa63b41ae94103f5538306a6b
     authentication: {}
@@ -1388,7 +1390,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360428670.9062
     method: PUT
-    modified: 1566336088171
+    modified: 1570479287517
     name: Modify zones of ping (remote) monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1397,8 +1399,47 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% response 'body',
-      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% response 'body',
+      'req_14223ed2c09e4d19b3e13e17fb7b1aa2', '$.id' %}"
+    _type: request
+  - _id: req_487687bd57a8452d9f0326fa61d40817
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "interval": null,
+          "details": {
+            "monitoringZones": null,
+            "plugin": {
+              "count": null
+            }
+          }
+        }
+    created: 1570479174228
+    description: ""
+    headers:
+      - id: pair_af6c3ee817db4eca9fca513196570a6d
+        name: Content-Type
+        value: application/json-patch+json
+      - id: pair_7278aaef4a7b46e58b241f2873c2cf95
+        name: ""
+        value: ""
+    isPrivate: false
+    metaSortKey: -1555360416600.4531
+    method: PATCH
+    modified: 1570485008834
+    name: Reset Ping Monitor Defaults
+    parameters: []
+    parentId: fld_2cd444041994485fa243cdab9f615271
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% response 'body',
+      'req_aef343eb6916447ca8507fe2d0617d38', 'b64::JC5jb250ZW50WzBdLmlk::46b',
+      'never' %}"
     _type: request
   - _id: req_f6d7a333dad54af885d22c15bdd00614
     authentication: {}
@@ -1409,7 +1450,7 @@ resources:
     isPrivate: false
     metaSortKey: -1555360404530
     method: DELETE
-    modified: 1561157976812
+    modified: 1570479292899
     name: Delete monitor
     parameters: []
     parentId: fld_2cd444041994485fa243cdab9f615271
@@ -1418,8 +1459,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/monitors/{% prompt 'Monitor ID',
-      '', '', '', false %}
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% prompt 'Monitor ID',
+      '', '', '', false %}"
     _type: request
   - _id: req_872b76e7e3684e939adc64afd9ac0b4e
     authentication: {}
@@ -1444,7 +1485,7 @@ resources:
     isPrivate: false
     metaSortKey: -1563231843254.5
     method: POST
-    modified: 1566241926279
+    modified: 1570479298677
     name: Test local monitor given resource
     parameters: []
     parentId: fld_5f92cca3cbdf44189e1ee614d0036b0f
@@ -1453,8 +1494,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/{% prompt 'Tenant', '', '', 'tenantId',
-      false, true %}/test-monitor
+    url: "{{ monitor_mgmt  }}/api/tenant/{% prompt 'Tenant', '', '', 'tenantId',
+      false, true %}/test-monitor"
     _type: request
   - _id: fld_5f92cca3cbdf44189e1ee614d0036b0f
     created: 1566236728350
@@ -1995,7 +2036,7 @@ resources:
     isPrivate: false
     metaSortKey: -1557984110656.5
     method: GET
-    modified: 1566336164342
+    modified: 1570482207825
     name: Get zones for tenant
     parameters: []
     parentId: fld_2e441e237d204e19a497bec0f751e4f1
@@ -2004,7 +2045,7 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8089/api/tenant/aaaaaa/zones?size=4&page=0
+    url: http://localhost:8089/api/tenant/aaaaaa/zones
     _type: request
   - _id: req_03e4492fd33841a9be7e627e9c17e6fb
     authentication: {}
@@ -4021,15 +4062,17 @@ resources:
     data:
       api_admin: localhost:8888
       api_public: localhost:8080/v1.0
+      monitor_mgmt: localhost:8089
       policy_mgmt: localhost:8091
     dataPropertyOrder:
       "&":
         - api_admin
         - api_public
         - policy_mgmt
+        - monitor_mgmt
     isPrivate: false
     metaSortKey: 1
-    modified: 1566411920262
+    modified: 1570479221219
     name: localhost
     parentId: env_5a5d52bd56ce4760af650078de6aa477
     _type: environment


### PR DESCRIPTION
I should have pushed these a sprint or two ago.

Adds various metadata policy stuff like

<img width="278" alt="image" src="https://user-images.githubusercontent.com/4358210/66328620-358dfd80-e8ea-11e9-8597-e54e873d36ec.png">


UPDATE: I was going to do the latter commits in a new PR, but since this wasn't approved yet I threw them in here.

They just add one request for the PATCH method, but also add an environment variable for the monitor-management endpoint which I've updated all those requests to utilize.