### PR TITLE
Match fluentd configuration to that used in our cluster deployments

### DIFF
--- a/dev/telemetry-infra/docker-compose-fluentd.yml
+++ b/dev/telemetry-infra/docker-compose-fluentd.yml
@@ -2,11 +2,9 @@ version: "3.4"
 
 services:
   fluentd:
-    image: fluentd
+    image: quay.io/fluentd_elasticsearch/fluentd:v2.7.0
     volumes:
-      - fluentd:/fluentd/log
+      - ./fluentd.conf:/etc/fluent/config.d/fluentd.conf
     ports:
       - 24224:24224
       - 24224:24224/udp
-volumes:
-  fluentd: {}

--- a/dev/telemetry-infra/fluentd.conf
+++ b/dev/telemetry-infra/fluentd.conf
@@ -1,0 +1,11 @@
+<source>
+  @type  forward
+  port  24224
+</source>
+<filter application.**>
+  @type record_transformer
+  remove_keys msg
+</filter>
+<filter **>
+  @type stdout
+</filter>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-715

# What

I noticed our infra service definition of fluentd didn't use the same image or config approach as our cluster deployed version. Bringing this in alignment allows us to confirm and experiment with configuration applicable to the deployed service.