### PR TITLE
Declare an optional zipkin service for testing

### DIFF
--- a/dev/telemetry-infra/docker-compose-zipkin.yml
+++ b/dev/telemetry-infra/docker-compose-zipkin.yml
@@ -1,0 +1,7 @@
+version: '3.2'
+
+services:
+  zipkin:
+    image: openzipkin/zipkin
+    ports:
+    - 9411:9411


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-725

# What

Preparing support for Zipkin by declaring an optional docker compose service to start zipkin service locally. It includes a web UI available at `http://localhost:9411`.