### PR TITLE
Restored the docs about ambassdor's run config needing working directory adjusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ IntelliJ, as of at least 2019.3, will auto-create run configurations for each of
 
 ![](img/active-profiles-dev.png)
 
-The run configuration for `apps/auth-service` needs the following "Override Parameters" set to the values returned by the [setup-app-role.sh script](#setting-up-vault-for-development-usage):
+The run configuration for `apps/auth-service` also needs the following "Override Parameters" set to the values returned by the [setup-app-role.sh script](#setting-up-vault-for-development-usage):
 ```
   vault.app-role.role-id
   vault.app-role.secret-id
 ```
+
+The run configuration for `apps/ambassador` also needs the "Working directory" set to the `dev` directory of this bundle module. That will ensure it can read the development-time certificates from the `certs` directory contained there.
 
 For example:
 ![](img/auth-service-props.png)


### PR DESCRIPTION
# What

In the previous PR https://github.com/racker/salus-telemetry-bundle/pull/96 I had accidentally removed the step in Ambassador's run config setup where the working directory needs to be adjusted.