### PR TITLE
Added data loader content as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "apps/packages-agent"]
 	path = apps/packages-agent
 	url = https://github.com/racker/salus-packages-agent.git
+[submodule "config/data-loader-content"]
+	path = config/data-loader-content
+	url = https://github.com/Rackspace-Segment-Support/salus-data-loader-content.git


### PR DESCRIPTION
# What

Added data loader content as a submodule especially since it is necessary during ongoing development to coordinate changes in that repo and the applications.

In Slack we discussed naming of this submodule path and decided the `config` subdirectory would be good since it is like the `dev` directory but supports all environments, such as production.