### PR TITLE
Added the ability to configure specific tenants in metrics-gen

### DIFF
--- a/dev/metrics-gen/k8s/pod.yaml
+++ b/dev/metrics-gen/k8s/pod.yaml
@@ -15,5 +15,6 @@ spec:
               key: bootstrap-servers
               name: salus-kafka
         - name: SALUS_GEN_TENANTS
-          value: "CHANGE THIS VALUE"
+          # Comma separated list of tenant IDs to use
+          value: "CONFIGURE TENANTS HERE"
   restartPolicy: Always

--- a/dev/metrics-gen/k8s/pod.yaml
+++ b/dev/metrics-gen/k8s/pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: salus-metrics-gen
+  labels:
+    app: salus-metrics-gen
+spec:
+  containers:
+    - name: salus-metrics-gen
+      image: salus-metrics-gen
+      env:
+        - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+          valueFrom:
+            configMapKeyRef:
+              key: bootstrap-servers
+              name: salus-kafka
+        - name: SALUS_GEN_TENANTS
+          value: "CHANGE THIS VALUE"
+  restartPolicy: Always

--- a/dev/metrics-gen/pom.xml
+++ b/dev/metrics-gen/pom.xml
@@ -33,6 +33,7 @@
 
   <properties>
     <java.version>11</java.version>
+    <docker.image-prefix/>
   </properties>
 
   <dependencies>
@@ -78,6 +79,16 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>2.0.0</version>
+        <configuration>
+          <to>
+            <image>${docker.image-prefix}salus-metrics-gen</image>
+          </to>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/dev/metrics-gen/skaffold.yaml
+++ b/dev/metrics-gen/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v1
+kind: Config
+metadata:
+  name: salus-metrics-gen
+build:
+  artifacts:
+    - image: salus-metrics-gen
+      jib: {}
+deploy:
+  kubectl: {}

--- a/dev/metrics-gen/src/main/java/com/rackspace/salus/metricsgen/config/MetricsGenProperties.java
+++ b/dev/metrics-gen/src/main/java/com/rackspace/salus/metricsgen/config/MetricsGenProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.rackspace.salus.metricsgen.config;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -28,15 +29,15 @@ import org.springframework.stereotype.Component;
 @Data
 public class MetricsGenProperties {
 
-  int tenants = 5;
+  List<String> tenants = List.of("tenant-00","tenant-01","tenant-02","tenant-03","tenant-04");
 
   int resourcesPerTenant = 20;
 
   Duration emitRate = Duration.ofSeconds(10);
 
-  String[] metrics = new String[]{"cpu", "memory", "disk"};
+  List<String> metrics = List.of("cpu", "memory", "disk");
 
-  String[] fields = new String[]{"free", "used", "current"};
+  List<String> fields = List.of("free", "used", "current");
 
   Map<String, String[]> labels = defaultLabels();
 

--- a/dev/metrics-gen/src/main/java/com/rackspace/salus/metricsgen/services/Generator.java
+++ b/dev/metrics-gen/src/main/java/com/rackspace/salus/metricsgen/services/Generator.java
@@ -69,8 +69,7 @@ public class Generator implements SmartLifecycle {
     for (String tenant : properties.getTenants()) {
 
       for (int r = 0; r < properties.getResourcesPerTenant(); r++) {
-        final String resourceId = String.format("resource-%03d",
-            r + properties.getResourcesPerTenant());
+        final String resourceId = String.format("resource-%03d", r);
 
         final Resource resource = new Resource()
             .setTenant(tenant)

--- a/dev/metrics-gen/src/main/java/com/rackspace/salus/metricsgen/services/Generator.java
+++ b/dev/metrics-gen/src/main/java/com/rackspace/salus/metricsgen/services/Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,12 +66,11 @@ public class Generator implements SmartLifecycle {
 
     final int minPeriod = (int) ((properties.getEmitRate().toMillis()/1000) * 2);
 
-    for (int t = 0; t < properties.getTenants(); t++) {
-      final String tenant = String.format("tenant-%02d", t);
+    for (String tenant : properties.getTenants()) {
 
       for (int r = 0; r < properties.getResourcesPerTenant(); r++) {
         final String resourceId = String.format("resource-%03d",
-            r + t*properties.getResourcesPerTenant());
+            r + properties.getResourcesPerTenant());
 
         final Resource resource = new Resource()
             .setTenant(tenant)
@@ -135,7 +134,7 @@ public class Generator implements SmartLifecycle {
 
       resource.getMetrics().forEach((metricName, metricSpec) -> {
         final ExternalMetric metric = ExternalMetric.newBuilder()
-            .setAccountType(AccountType.UNKNOWN)
+            .setAccountType(AccountType.RCN)
             .setAccount(resource.getTenant())
             .setMonitoringSystem(MonitoringSystem.SALUS)
             .setCollectionName(metricName)


### PR DESCRIPTION
Also added jib and skaffold support for dev cluster deployment

# Resolves

https://jira.rax.io/browse/SALUS-776

# What

Since the dev cluster's kafka is not external accessible, I needed a way to run metrics-gen as a pod within the dev cluster. I also needed to generate metrics against my own particular tenant so that I could create the event tasks via the normal public API authentication.

# How

Swapped the `tenants` parameter from a "count of tenants" to a "list of tenant IDs".

Added jib maven plugin and skaffold config so that we can use Cloud Cloud in IntelliJ to deploy metrics-gen to the dev cluster.