### PR TITLE
Allow service-admins to access any tenant without requiring impersonation

### DIFF
--- a/dev/telemetry-apps/repose-config/keystone-v2-authorization.cfg.xml
+++ b/dev/telemetry-apps/repose-config/keystone-v2-authorization.cfg.xml
@@ -3,6 +3,9 @@
                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                            xsi:schemaLocation="http://docs.openrepose.org/repose/keystone-v2/v1.0 http://www.openrepose.org/versions/latest/schemas/keystone-v2-authorization.xsd">
 
+    <pre-authorized-roles>
+        <role>monitoring:service-admin</role>
+    </pre-authorized-roles>
     <tenant-handling>
         <validate-tenant>
             <header-extraction-name>Requested-Tenant-Id</header-extraction-name>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-733

# What

Update Repose to handle monitoring:service-admin users

# How

https://repose.atlassian.net/wiki/spaces/REPOSE/pages/34275336/Keystone+v2+filter#Keystonev2filter-BypassingTenantIDValidationbyRole

Bypass tenant validation for `monitoring:service-admin` users.

## How to test

Locally using https://github.com/racker/salus-telemetry-bundle#running-the-docker-application-images

# Why

To allow service users, such as RBA/Servermill to access our API without impersonating each account we will need to update repose to let tokens with the monitoring:service-admin role pass through without verifying against the tenant in the URL.

# TODO

A PR to the repose we actually deploy.
