### PR TITLE
Updated repose-authserv to 404 disallowed paths

### DIFF
--- a/dev/repose-authserv/docker-compose.yml
+++ b/dev/repose-authserv/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   repose:
     image: rackerlabs/repose:${REPOSE_VERSION:-9.0.1.0}
     environment:
+      # use special hostname to route to auth service running in IntelliJ
       BACKEND_HOST: ${BACKEND_HOST:-host.docker.internal}
       BACKEND_PORT: ${BACKEND_PORT:-8082}
     ports:

--- a/dev/repose-authserv/docker-compose.yml
+++ b/dev/repose-authserv/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3.7'
 
 services:
   repose:
-    image: rackerlabs/repose:${REPOSE_VERSION:-9.0.0.0}
+    image: rackerlabs/repose:${REPOSE_VERSION:-9.0.1.0}
+    environment:
+      BACKEND_HOST: ${BACKEND_HOST:-host.docker.internal}
+      BACKEND_PORT: ${BACKEND_PORT:-8082}
     ports:
       - 8180:8080
     volumes:

--- a/dev/repose-authserv/repose-config/scripting-200.cfg.xml
+++ b/dev/repose-authserv/repose-config/scripting-200.cfg.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ Copyright 2020 Rackspace US, Inc.
   ~
@@ -14,10 +16,7 @@
   ~ limitations under the License.
   -->
 
-<destination-router xmlns="http://docs.openrepose.org/repose/destination-router/v1.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://docs.openrepose.org/repose/destination-router/v1.0 http://www.openrepose.org/versions/9.1.0.0/schemas/destination-router-configuration.xsd">
-
-  <target id="cert"/>
-
-</destination-router>
+<scripting xmlns="http://docs.openrepose.org/repose/scripting/v1.0"
+           language="python">
+response.setStatus(200)
+</scripting>

--- a/dev/repose-authserv/repose-config/scripting-404.cfg.xml
+++ b/dev/repose-authserv/repose-config/scripting-404.cfg.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ Copyright 2020 Rackspace US, Inc.
   ~
@@ -14,10 +16,7 @@
   ~ limitations under the License.
   -->
 
-<destination-router xmlns="http://docs.openrepose.org/repose/destination-router/v1.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://docs.openrepose.org/repose/destination-router/v1.0 http://www.openrepose.org/versions/9.1.0.0/schemas/destination-router-configuration.xsd">
-
-  <target id="cert"/>
-
-</destination-router>
+<scripting xmlns="http://docs.openrepose.org/repose/scripting/v1.0"
+           language="python">
+response.setStatus(404)
+</scripting>

--- a/dev/repose-authserv/repose-config/system-model.cfg.xml
+++ b/dev/repose-authserv/repose-config/system-model.cfg.xml
@@ -24,6 +24,16 @@
     <node id="repose_node1" hostname="localhost" http-port="8080"/>
   </nodes>
   <filters>
+    <filter name="scripting" configuration="scripting-200.cfg.xml" uri-regex="/healthcheck"/>
+    <filter name="scripting" configuration="scripting-404.cfg.xml">
+      <!-- respond with 404 to anything that's NOT the  -->
+      <not> <!-- criteria within must be same as destination-router below -->
+        <and>
+          <methods value="GET"/>
+          <uri regex="/v1.0/cert"/>
+        </and>
+      </not>
+    </filter>
     <filter name="destination-router" configuration="destination-router-cert.cfg.xml">
       <and>
         <methods value="GET"/>
@@ -33,7 +43,7 @@
   </filters>
   <destinations>
     <!-- use special hostname to route to auth service running in IntelliJ -->
-    <endpoint id="cert" protocol="http" hostname="host.docker.internal" root-path="/" port="8082"/>
+    <endpoint id="cert" protocol="http" hostname="{$ BACKEND_HOST $}" root-path="/" port="{$ BACKEND_PORT $}"/>
     <endpoint id="blackhole" default="true"/>
   </destinations>
 </system-model>

--- a/dev/repose-authserv/repose-config/system-model.cfg.xml
+++ b/dev/repose-authserv/repose-config/system-model.cfg.xml
@@ -26,8 +26,12 @@
   <filters>
     <filter name="scripting" configuration="scripting-200.cfg.xml" uri-regex="/healthcheck"/>
     <filter name="scripting" configuration="scripting-404.cfg.xml">
-      <!-- respond with 404 to anything that's NOT the  -->
-      <not> <!-- criteria within must be same as destination-router below -->
+      <!--
+      Respond with 404 to anything that's NOT the /v1.0/cert API that should be served
+      directly by auth-service. Its public APIs will be routed via the public API
+      instance of Repose where Identity/Keystone authentication is performed.
+       -->
+      <not>
         <and>
           <methods value="GET"/>
           <uri regex="/v1.0/cert"/>

--- a/dev/repose-authserv/repose-config/system-model.cfg.xml
+++ b/dev/repose-authserv/repose-config/system-model.cfg.xml
@@ -46,7 +46,6 @@
     </filter>
   </filters>
   <destinations>
-    <!-- use special hostname to route to auth service running in IntelliJ -->
     <endpoint id="cert" protocol="http" hostname="{$ BACKEND_HOST $}" root-path="/" port="{$ BACKEND_PORT $}"/>
     <endpoint id="blackhole" default="true"/>
   </destinations>


### PR DESCRIPTION
# Resolves

Helps with https://jira.rax.io/browse/SALUS-862

# What

- Use the same `BACKEND_HOST` and `BACKEND_PORT` variable placeholders so these same files can be used as deployment
- Bumped repose version to match deployment
- Added same `/healthcheck` response filter as deployment, but rename its config file to be "200" specific
- Added a similar scripting approach to respond 404 to all paths except the `/v1.0/cert` one that is allowed

I still wish I could find a better way to whitelist specific paths in Repose, but these changes now work as I really wanted in the first place.