### PR TITLE
Added docker composition to do one-off monitoring of etcd

### DIFF
--- a/dev/envoy-config-gke-perf.yml
+++ b/dev/envoy-config-gke-perf.yml
@@ -1,0 +1,17 @@
+# NOTE
+# Purposely omits resource_id since each developer should provide a unique value
+# It is recommended that the --resource-id command line arg be used to specify resourceId.
+
+tls:
+  auth_service:
+    url: https://salus-auth-serv.perf.monplat.rackspace.net
+ambassador:
+  address: salus-ambassador.perf.monplat.rackspace.net:443
+ingest:
+  lumberjack:
+    bind: ""
+  telegraf:
+    json:
+      bind: localhost:8094
+agents:
+  dataPath: data-telemetry-envoy

--- a/dev/monitor-etcd/README.md
+++ b/dev/monitor-etcd/README.md
@@ -1,0 +1,13 @@
+This composition starts a Prometheus instance that can be configured to monitor a locally deployed etcd from [the infra composition](../telemetry-infra) (the default) or a port-forwarded etcd instance such as from the perf or dev cluster. 
+
+A port-forwarding to a Kubernetes deployed instance can be created with:
+
+```
+kubectl port-forward pod/etcd-0 32379:2379
+```
+
+You will need to uncomment the documented section in [prometheus.yml](prometheus.yml) to configure a scrape of the port-forwarded instance.
+
+The Prometheus dashboard is accessible at http://localhost:9090/. Specifically, the http://localhost:9090/targets view can be used to confirm the scraping of the etcd instance(s).
+
+The Grafana dashboard is available at http://localhost:3000 where the initial credentials are admin/admin. [Dashboard ID 3070](https://grafana.com/grafana/dashboards/3070) can be imported at http://localhost:3000/dashboard/import to setup etcd visibility.

--- a/dev/monitor-etcd/docker-compose.yml
+++ b/dev/monitor-etcd/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.7"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.17.1
+    ports:
+      - 9090:9090
+    networks:
+      - infra
+      - grafana
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-6.7.2}
+    ports:
+      - 3000:3000
+    networks:
+      - grafana
+    volumes:
+      - ./grafana-config/datasources.yml:/etc/grafana/provisioning/datasources/main.yml:ro
+      - ./grafana-config/dashboards:/dashboards:ro
+      - grafana:/var/lib/grafana
+
+volumes:
+  grafana: {}
+
+networks:
+  infra:
+    external: true
+    name: telemetry-infra_default
+  grafana: {}

--- a/dev/monitor-etcd/grafana-config/datasources.yml
+++ b/dev/monitor-etcd/grafana-config/datasources.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090

--- a/dev/monitor-etcd/prometheus.yml
+++ b/dev/monitor-etcd/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 10s
+scrape_configs:
+  # Only one of these jobs should be enabled since published dashboards for Grafana, such as
+  # https://grafana.com/grafana/dashboards/3070 assume only a single cluster is being monitored.
+#  - job_name: etcd_local
+#    static_configs:
+#      - targets:
+#          - etcd:2379
+#        labels:
+#          location: local
+  - job_name: etcd_remote
+    static_configs:
+      - targets:
+          # Use kubectl port-forward pod/etcd-0 32379:2379
+          - host.docker.internal:32379
+        labels:
+          location: remote

--- a/dev/telemetry-infra/README.md
+++ b/dev/telemetry-infra/README.md
@@ -3,9 +3,6 @@
 This can be used for local testing, such as verifying new counter metrics are appearing as expected.
 
 1. Start the two containers using `docker-compose -f docker-compose-influxdb.yml up -d`
-1. Browse to http://localhost:3000/datasources which should open up the data sources view in Grafana
-1. Select InfluxDB (or create it if one doesn't exist)
-1. Specify `http://influxdb:8086` for the URL
-1. Test & Save the configuration
-
-You should now be able to create & edit dashboards to contain your new metrics.
+1. Access Grafana at http://localhost:3000
+   > The default credentials are admin / admin . When prompted to change the password, you can always "change" it to "admin" for simplicity
+1. The InfluxDB data source is pre-configured by grafana, so you should now be able to create & edit dashboards to contain your new metrics.

--- a/dev/telemetry-infra/docker-compose-influxdb.yml
+++ b/dev/telemetry-infra/docker-compose-influxdb.yml
@@ -11,11 +11,12 @@ services:
       INFLUXDB_DB: salus
 
   grafana:
-    image: grafana/grafana:5.4.3
+    image: grafana/grafana:${GRAFANA_VERSION:-6.7.2}
     ports:
       - 3000:3000
     volumes:
       - grafana:/var/lib/grafana
+      - ./grafana-config/datasources.yml:/etc/grafana/provisioning/datasources/main.yml:ro
 
 volumes:
   influxdb:

--- a/dev/telemetry-infra/docker-compose.yml
+++ b/dev/telemetry-infra/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   etcd:
-    image: quay.io/coreos/etcd:latest
+    image: quay.io/coreos/etcd:${ETCD_VERSION:-v3.3.20}
     ports:
       - 2479:2379
     volumes:

--- a/dev/telemetry-infra/grafana-config/datasources.yml
+++ b/dev/telemetry-infra/grafana-config/datasources.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    database: salus
+    url: http://influxdb:8086


### PR DESCRIPTION
# What

At one point during the performance testing of 5000 envoy connections to an ambassador I suspected etcd was having problems. Turned out it didn't, but thought I'd push these changes for a one-off monitoring solution anyway.

Taking [what I learned from that grafana setup](https://grafana.com/docs/grafana/latest/administration/provisioning/#datasources), I built upon https://github.com/racker/salus-telemetry-bundle/pull/116 to pre-declare an influxdb datasource in our existing infra instance of influxdb+grafana.

I also added an envoy config that I have been using for running `envoy stress-connections` locally against the perf cluster.