### PR TITLE
Consolidated Vault app setup into the one section

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,7 @@ IntelliJ, as of at least 2019.3, will auto-create run configurations for each of
 
 ![](img/active-profiles-dev.png)
 
-The run configuration for `apps/auth-service` also needs the following "Override Parameters" set to the values returned by the [setup-app-role.sh script](#setting-up-vault-for-development-usage):
-```
-  vault.app-role.role-id
-  vault.app-role.secret-id
-```
-
 The run configuration for `apps/ambassador` also needs the "Working directory" set to the `dev` directory of this bundle module. That will ensure it can read the development-time certificates from the `certs` directory contained there.
-
-For example:
-![](img/auth-service-props.png)
 
 Go based modules, such as `apps/envoy`, may not be auto-detected as modules initially. If that's the case, then open the Project Structure configuration and perform an "Import Module" operation as shown here:
 
@@ -170,6 +161,10 @@ to be used by the Salus applications:
 ```bash
 docker exec -it telemetry-infra_vault_1 setup-app-role
 ```
+
+Using the `vault.app-role.role-id` and `vault.app-role.secret-id` provided by that script, update the run configuration for `apps/auth-service` in the "Override Parameters" section, such as
+
+![](img/auth-service-props.png)
 
 ## Interacting with local infrastructure services
 While debugging issues it can be helpful to view what the applications running it docker are doing.


### PR DESCRIPTION
# What

When I shifted the optional Vault configuration into its own section I missed a couple of references in the required/mainline setup flow.