### PR TITLE
Add salus-event-handler to apps submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "config/data-loader-content"]
 	path = config/data-loader-content
 	url = https://github.com/Rackspace-Segment-Support/salus-data-loader-content.git
+[submodule "apps/event-handler"]
+	path = apps/event-handler
+	url = git@github.com:racker/salus-event-handler.git


### PR DESCRIPTION
Adding the new repo that'll be used to consume events from Kapacitor and (initially) perform consolidation to calculate quorum.