### PR TITLE
 Add policy opt-out endpoints

### DIFF
--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2020-07-20T17:47:55.830Z
+__export_date: 2020-07-20T18:04:41.349Z
 __export_source: insomnia.desktop.app:v2020.3.0
 resources:
   - _id: req_e8b1565dab71459983d06f366d58e02b
@@ -2925,7 +2925,7 @@ resources:
     isPrivate: false
     metaSortKey: -1564981571270.5
     method: GET
-    modified: 1570564981622
+    modified: 1595267682274
     name: Get monitor by id
     parameters: []
     parentId: fld_52f2a23df31449f6935c3be8b1a99796
@@ -2935,8 +2935,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors/{% prompt 'Monitor ID', '', '', false,      false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors/{% prompt 'Monitor ID', '', '', false,      false %}"
     _type: request
   - _id: req_ce664bb03fd641088890a6bcc6470f4c
     authentication: {}
@@ -3043,8 +3043,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/schema/monitor-plugins"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/schema/monitor-plugins"
     _type: request
   - _id: req_42f47e1a4e1645bdbbedb5891ef140ab
     authentication: {}
@@ -3069,8 +3069,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/schema/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/schema/monitors"
     _type: request
   - _id: req_388b2c4a4aeb4b9988aa26417b4213ef
     authentication: {}
@@ -3112,8 +3112,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_0ac44373720e45cf9e49a800310526a9
     authentication: {}
@@ -3198,8 +3198,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_934340a540e543f78707a5842ea86d8c
     authentication: {}
@@ -3242,8 +3242,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_20f4815ecac848d2aecb93f222c553e3
     authentication: {}
@@ -3284,8 +3284,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_9a32cc404b84432abd8be6868f31e964
     authentication: {}
@@ -3327,8 +3327,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_db7ef2a210254efbb61e17a89e4a0ecb
     authentication: {}
@@ -3370,8 +3370,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_7c624489cab344e9ae843223a515a701
     authentication: {}
@@ -3414,8 +3414,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_5b7a9a8ba3ca412baaaa225c92dfe561
     authentication: {}
@@ -3459,8 +3459,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_c97b79a2d79c4b55b8f5910676d31c9c
     authentication: {}
@@ -3503,8 +3503,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_45121a7c3e4b4475add793f0069e596e
     authentication: {}
@@ -3546,8 +3546,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_1f7f0f664a704588bc91fe7218b67c41
     authentication: {}
@@ -3678,8 +3678,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/monitors/{% prompt 'Monitor ID', '', '', false,      false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors/{% prompt 'Monitor ID', '', '', false,      false %}"
     _type: request
   - _id: req_97d1a7f4ba5e43538bd14377e8b48f11
     authentication: {}
@@ -3700,9 +3700,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/resources/{% prompt 'resourceId', 'Resource Id', '', '', false
-      %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resources/{% prompt 'resourceId', 'Resource Id', '', '', false %}"
     _type: request
   - _id: fld_0a6a98b5c25d42b2a28631f09356c466
     created: 1552328968587
@@ -3775,8 +3774,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/resources-by-label"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resources-by-label"
     _type: request
   - _id: req_0bf451e67e3540f382cad90292616ea6
     authentication: {}
@@ -3864,8 +3863,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/resources"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resources"
     _type: request
   - _id: req_095d7117448940218ceec966f4049f14
     authentication: {}
@@ -3889,8 +3888,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/resources/{% prompt 'deletedResourceId', 'Deleted Resource Id',
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resources/{% prompt 'deletedResourceId', 'Deleted Resource Id',
       '', '', false %}"
     _type: request
   - _id: req_7b604db998f54a19bcab67504ab7ee33
@@ -4322,8 +4321,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/zones"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/zones"
     _type: request
   - _id: req_51e7462f7510485487cc303dde2c067e
     authentication: {}
@@ -4347,8 +4346,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', 'aaaaaa', '',
-      false %}/rebalance-zone/{% prompt 'Zone Name', '', '', '', false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/rebalance-zone/{% prompt 'Zone Name', '', '', '', false %}"
     _type: request
   - _id: req_bc344ee5b97e4ebca705453b2c5e5443
     authentication: {}
@@ -5007,7 +5006,7 @@ resources:
     isPrivate: false
     metaSortKey: -1573938682001
     method: GET
-    modified: 1580481808959
+    modified: 1595268259784
     name: Get effective metadata policy by tenant
     parameters: []
     parentId: fld_eb600b387c26452d9deb62946fdef63d
@@ -5018,7 +5017,7 @@ resources:
     settingSendCookies: true
     settingStoreCookies: true
     url: "{{ api_admin  }}/api/policy/metadata/monitor/effective/{% prompt 'Tenant
-      Id', 'tenantId', 'aaaaaa', '', false, true %}"
+      Id', 'tenantId', '', '', false, true %}"
     _type: request
   - _id: req_8afb6e7fa3bb4fc8a2a00dace61fe7be
     authentication: {}
@@ -5033,7 +5032,7 @@ resources:
     isPrivate: false
     metaSortKey: -1567561570834
     method: GET
-    modified: 1580481812617
+    modified: 1595268105993
     name: Get effective policy for tenant and monitor type
     parameters: []
     parentId: fld_eb600b387c26452d9deb62946fdef63d
@@ -5044,9 +5043,9 @@ resources:
     settingSendCookies: true
     settingStoreCookies: true
     url: "{{ api_admin  }}/api/policy/metadata/monitor/effective/{% prompt 'Tenant
-      Id', 'tenantId', 'aaaaaa', '', false, true %}/{% prompt 'Target Class
-      Name', 'className', 'Monitor', '', false, true %}/{% prompt 'Monitor
-      Type', 'monitorType', 'mem', '', false, true %}"
+      Id', 'tenantId', '', '', false, true %}/{% prompt 'Target Class Name',
+      'className', 'Monitor', '', false, true %}/{% prompt 'Monitor Type',
+      'monitorType', 'mem', '', false, true %}"
     _type: request
   - _id: req_0fa69e356a0d45559a4eb20adaf94848
     authentication: {}

--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1,7 +1,7 @@
 _type: export
 __export_format: 4
-__export_date: 2020-06-23T14:15:42.980Z
-__export_source: insomnia.desktop.app:v7.1.1
+__export_date: 2020-07-20T17:47:55.830Z
+__export_source: insomnia.desktop.app:v2020.3.0
 resources:
   - _id: req_e8b1565dab71459983d06f366d58e02b
     authentication: {}
@@ -50,6 +50,7 @@ resources:
     modified: 1543593177069
     name: Salus Telemetry
     parentId: null
+    scope: null
     _type: workspace
   - _id: req_eb0a6187b182455dbaae0fe08ec3487e
     authentication: {}
@@ -643,8 +644,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8085/api/tenant/{% prompt 'tenantId', 'Tenant Id', '',
-      '', false, true %}/resource-metadata-keys
+    url: http://localhost:8085/api/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
+      false, true %}/resource-metadata-keys
     _type: request
   - _id: req_18a9a92233e94334b94e2c4f595e6394
     authentication: {}
@@ -681,8 +682,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: localhost:8085/api/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/resources
+    url: localhost:8085/api/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resources
     _type: request
   - _id: req_2493bc18d29142f8a365a9fd3f5b7af6
     authentication: {}
@@ -1690,8 +1691,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% prompt 'Monitor ID',
-      '', '', '', false %}"
+    url: "{{ monitor_mgmt  }}/api/tenant/aaaaaa/monitors/{% prompt 'Monitor ID', '',
+      '', '', false %}"
     _type: request
   - _id: req_872b76e7e3684e939adc64afd9ac0b4e
     authentication: {}
@@ -2742,9 +2743,9 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: http://localhost:8090/api/admin/bound-agent-installs/{% prompt 'Tenant
-      ID', '', '', 'tenantId', false %}/{% prompt 'Resource ID', '', '', '',
-      false %}/{% prompt 'Agent type', 'TELEGRAF | FILEBEAT', '', '', false %}
+    url: http://localhost:8090/api/admin/bound-agent-installs/{% prompt 'Tenant ID',
+      '', '', 'tenantId', false %}/{% prompt 'Resource ID', '', '', '', false
+      %}/{% prompt 'Agent type', 'TELEGRAF | FILEBEAT', '', '', false %}
     _type: request
   - _id: req_3f90cdea1bab41868f8be78f4733359b
     authentication: {}
@@ -2966,8 +2967,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_1e3562f16c534becb8d765f5a68c67b2
     authentication: {}
@@ -2991,8 +2992,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/bound-monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/bound-monitors"
     _type: request
   - _id: req_fcbe7745bd3a409ba570bda1c6df1e17
     authentication: {}
@@ -3016,8 +3017,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/monitor-label-selectors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitor-label-selectors"
     _type: request
   - _id: req_f3b9e4fd80c94a479f039369d52358c5
     authentication: {}
@@ -3156,8 +3157,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/monitors"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors"
     _type: request
   - _id: req_46e3a88ab1064b9fbef61010a7abde9f
     authentication: {}
@@ -3618,9 +3619,9 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/monitors/{% prompt 'Monitor ID', 'monitorId', '', '',
-      false, true %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/monitors/{% prompt 'Monitor ID', 'monitorId', '', '', false, true
+      %}"
     _type: request
   - _id: req_2c8f05653c934cf0a85d6526154cbd95
     authentication: {}
@@ -3652,8 +3653,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/monitors/{% prompt 'Monitor ID', '', '', '', false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/monitors/{% prompt 'Monitor ID', '', '', '', false %}"
     _type: request
   - _id: req_e6c07cfdbeb04c91bf2cc2995887de25
     authentication: {}
@@ -3746,8 +3747,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/resources"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resources"
     _type: request
   - _id: req_8cb39d8dec0c4dda9bfaeccb329839d5
     authentication: {}
@@ -3800,8 +3801,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/resource-labels"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resource-labels"
     _type: request
   - _id: req_5349e0b79a5b48978753d191f332a524
     authentication: {}
@@ -3826,8 +3827,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/resource-metadata-keys"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/resource-metadata-keys"
     _type: request
   - _id: req_714bac3a6790412eb532e36d2de1e737
     authentication: {}
@@ -3911,8 +3912,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant Id', 'tenantId', '', '',
-      false, true %}/event-tasks/{% prompt 'Task Id', '', '', '', false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant Id', 'tenantId', '', '', false,
+      true %}/event-tasks/{% prompt 'Task Id', '', '', '', false %}"
     _type: request
   - _id: fld_906f0421bdb54818a4abb19bd58a8d21
     created: 1552841089415
@@ -3952,8 +3953,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/event-tasks"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/event-tasks"
     _type: request
   - _id: req_ff8e3b0f818e4ed8a5c8936292084b96
     authentication: {}
@@ -4002,8 +4003,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/event-tasks"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/event-tasks"
     _type: request
   - _id: req_92fe7c03ce20411d8a69644239f6d26b
     authentication: {}
@@ -4027,8 +4028,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant Id', 'tenantId', '', '',
-      false, true %}/event-tasks/{% prompt 'Task Id', '', '', '', false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant Id', 'tenantId', '', '', false,
+      true %}/event-tasks/{% prompt 'Task Id', '', '', '', false %}"
     _type: request
   - _id: req_a0da3e16e8da4cd3954bd9ea13259f25
     authentication: {}
@@ -4052,8 +4053,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/agent-releases"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/agent-releases"
     _type: request
   - _id: fld_b073af8590104e8b904c2fda7654403b
     created: 1537893080573
@@ -4088,8 +4089,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/agent-installs"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/agent-installs"
     _type: request
   - _id: req_a0a42d95a1544c6b9888a97e7662b6ae
     authentication: {}
@@ -4125,8 +4126,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/agent-installs"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/agent-installs"
     _type: request
   - _id: req_424edec546d143e99cf97e73050fa276
     authentication: {}
@@ -4162,8 +4163,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/agent-installs"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/agent-installs"
     _type: request
   - _id: req_58bd8f171d774346a76211761cda80b4
     authentication: {}
@@ -4199,8 +4200,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/agent-installs"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/agent-installs"
     _type: request
   - _id: req_59edf223a275414887b2bda27a3d9b56
     authentication: {}
@@ -4221,9 +4222,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/agent-installs/{% prompt 'Agent install ID', '', '', '',
-      false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/agent-installs/{% prompt 'Agent install ID', '', '', '', false %}"
     _type: request
   - _id: req_0de992a88708403c802b6e63828d80cd
     authentication: {}
@@ -4247,8 +4247,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/zones"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/zones"
     _type: request
   - _id: fld_b1a0cdb8cd1f47e19712886ffa3cdd39
     created: 1559311403559
@@ -4282,9 +4282,9 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '',
-      false, true %}/zone-assignment-counts/{% prompt 'Zone Name', '', '', '',
-      false %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'tenantId', 'Tenant Id', '', '', false,
+      true %}/zone-assignment-counts/{% prompt 'Zone Name', '', '', '', false
+      %}"
     _type: request
   - _id: req_1f8425184cdc49be8162c73a989c94d1
     authentication: {}
@@ -4383,8 +4383,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/envoy-tokens"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/envoy-tokens"
     _type: request
   - _id: fld_0c4f18cc71474ed4aa981c4cf0e3cc33
     created: 1585757326415
@@ -4429,8 +4429,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/envoy-tokens"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/envoy-tokens"
     _type: request
   - _id: req_c315f1c45c68465083afbf18c291656b
     authentication: {}
@@ -4457,8 +4457,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/envoy-tokens/{% prompt 'Token', '', '', '', false, true %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/envoy-tokens/{% prompt 'Token', '', '', '', false, true %}"
     _type: request
   - _id: req_17d2a1eeff4e4dfda262e46a3bcf5edf
     authentication: {}
@@ -4493,8 +4493,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/envoy-tokens/{% prompt 'Token', '', '', '', false, true %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/envoy-tokens/{% prompt 'Token', '', '', '', false, true %}"
     _type: request
   - _id: req_c66c0968bae5465c8a7cfcb02da762ea
     authentication: {}
@@ -4521,8 +4521,8 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '',
-      false, true %}/envoy-tokens/{% prompt 'Token', '', '', '', false, true %}"
+    url: "{{ api_public  }}/tenant/{% prompt 'Tenant ID', 'tenantId', '', '', false,
+      true %}/envoy-tokens/{% prompt 'Token', '', '', '', false, true %}"
     _type: request
   - _id: req_1722c11f078b45ed99f9f4acb3a492f8
     authentication: {}
@@ -5603,6 +5603,14 @@ resources:
     name: Default Jar
     parentId: wrk_ac0b38d28c244065bf230518f9dd3e75
     _type: cookie_jar
+  - _id: spc_92128f267e0f44169da380e91fb7f057
+    contentType: yaml
+    contents: ""
+    created: 1595267232651
+    fileName: Salus Telemetry
+    modified: 1595267232651
+    parentId: wrk_ac0b38d28c244065bf230518f9dd3e75
+    _type: api_spec
   - _id: env_2953bcf7752f45b6b91078759cd379a2
     color: null
     created: 1533148524042

--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2020-07-20T18:04:41.349Z
+__export_date: 2020-07-20T18:25:32.218Z
 __export_source: insomnia.desktop.app:v2020.3.0
 resources:
   - _id: req_e8b1565dab71459983d06f366d58e02b
@@ -171,6 +171,37 @@ resources:
     settingStoreCookies: true
     url: http://{{ policy_mgmt  }}/api/admin/policy/monitors/{% prompt 'Monitor
       Policy Id', 'policyId', '', '', false, false %}
+    _type: request
+  - _id: req_ef0b5433331b4013a94609f35a405ddc
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: >-
+        {
+          "scope": "TENANT",
+          "subscope": "{% prompt 'Tenant Id', 'Tenant', '', '', false, true %}",
+          "name": "{% prompt 'Policy Name', 'PolicyName', '', '', false, true %}"
+        }
+    created: 1595268494659
+    description: ""
+    headers:
+      - id: pair_7102654e33034c86b3a31b202e66175f
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1565756377259.1562
+    method: POST
+    modified: 1595269381761
+    name: Opt-Out
+    parameters: []
+    parentId: fld_7876677d6cfa4e828deefa45a4aeccf5
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingFollowRedirects: global
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: http://{{ policy_mgmt  }}/api
     _type: request
   - _id: req_eeda52ec03e94f838cf8eb28b23d6fff
     authentication: {}
@@ -4859,6 +4890,37 @@ resources:
     settingStoreCookies: true
     url: "{{ api_admin  }}/api/policy-monitors/{% prompt 'Policy Monitor Id',
       'policyMonitorId', '', '', false, false %}"
+    _type: request
+  - _id: req_2ab7a5a0374b4d3b8c51159a1c241773
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: >-
+        {
+          "scope": "TENANT",
+          "subscope": "{% prompt 'Tenant Id', 'Tenant', '', '', false, true %}",
+          "name": "{% prompt 'Policy Name', 'PolicyName', '', '', false, true %}"
+        }
+    created: 1595269410995
+    description: ""
+    headers:
+      - id: pair_f6132ee6398b46b693b2da44058db0ec
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1566325762637
+    method: POST
+    modified: 1595269492996
+    name: Opt-Out
+    parameters: []
+    parentId: fld_b15f6baa7b284d78afa7fe13cdbfd0bc
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingFollowRedirects: global
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ api_admin  }}/api/policies/monitors/opt-out"
     _type: request
   - _id: req_af0655ae445341038011fcad9796e3a6
     authentication: {}


### PR DESCRIPTION
Once https://github.com/racker/salus-telemetry-bundle/pull/125 is merged I think the diff for this will clean itself up.

Adds direct and admin api endpoints for opting  out of policies.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/4358210/87972573-5e037480-ca84-11ea-8fe1-cf3637c20090.png">

... while making this I did question why I didn't include the tenantId as a path param.  Doing that would allow us to make the payload only be the `name` of the policy instead of also requiring scope/subscope.  Maybe I'll change that in future.