### PR TITLE
Add salus-event-engine-processor to apps submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "apps/event-handler"]
 	path = apps/event-handler
 	url = git@github.com:racker/salus-event-handler.git
+[submodule "apps/event-engine-processor"]
+	path = apps/event-engine-processor
+	url = git@github.com:racker/salus-event-engine-processor.git


### PR DESCRIPTION
This is the service that will contain the logic for: 

1. Ingesting metrics from UMB
1. Passing them through esper
1. Outputting state change events to UMB

I'll remove the event-handler submodule once we're sure we don't want to use it.