### PR TITLE
Add event processor dev port

### DIFF
--- a/dev/dev-ports.md
+++ b/dev/dev-ports.md
@@ -26,5 +26,6 @@ Port | Application / Usage
 8089 | Monitor Management
 8090 | Agent Catalog Management
 8091 | Policy Management
+8092 | Event Engine Processor
 8433 | Admin API when running with `ssl` profile activated
 8888 | Admin API


### PR DESCRIPTION
I'm using this port locally now.  It'll be included in the first processor PR.