### PR TITLE
Remove event-handler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,9 +70,6 @@
 [submodule "config/data-loader-content"]
 	path = config/data-loader-content
 	url = https://github.com/Rackspace-Segment-Support/salus-data-loader-content.git
-[submodule "apps/event-handler"]
-	path = apps/event-handler
-	url = git@github.com:racker/salus-event-handler.git
 [submodule "apps/event-engine-processor"]
 	path = apps/event-engine-processor
 	url = git@github.com:racker/salus-event-engine-processor.git


### PR DESCRIPTION
A little cleanup.

We decided to do everything in event-engine-processor so this module is no longer needed.