### PR TITLE
added Monitors request_group as that was removed in prev PRs.

### DIFF
--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -2924,6 +2924,16 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: fld_52f2a23df31449f6935c3be8b1a99796
+    parentId: fld_3373074209bc49199beb8e5967f1ae4a
+    modified: 1556919007811
+    created: 1552575315822
+    name: Monitors
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1552638807215
+    _type: request_group  
   - _id: req_01cf5de9c6b149d3b01670c6adb4895a
     parentId: fld_52f2a23df31449f6935c3be8b1a99796
     modified: 1595267682274


### PR DESCRIPTION
# Resolves

[SALUS-1091](https://jira.rax.io/browse/SALUS-1091)

# What

Policy-Monitors for tenant from public apis was been removed earlier but along with that request group "Monitors" was also removed. So, we were not getting Monitor API in public apis groups.

# How

Added request group for "Monitors" in insomnia file.